### PR TITLE
[1차시] 남우성 - 백준 2631, 10164

### DIFF
--- a/남우성/1차시/10164.jav
+++ b/남우성/1차시/10164.jav
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		int[][] dp = new int[N][M];
+		int[] mustPos = {0, 0};
+		if(K > 0) { // K가 존재하는 경우, 좌표를 계산
+			mustPos[0] = (K-1) / M;
+			mustPos[1] = (K-1) % M;
+		}
+		
+		// dp로 전체 좌표의 경우의 수를 계산
+		for(int i = 0; i < M; i++) {
+			dp[0][i] = 1;
+		}
+		for(int i = 0; i < N; i++) {
+			dp[i][0] = 1;
+		}
+		for(int i = 1; i < N; i++){
+			for(int j = 1; j < M; j++) {
+				dp[i][j] = dp[i-1][j] + dp[i][j-1];
+			}
+		}
+		
+		// K 존재 여부로 case를 나눔
+		if( K == 0) {
+			bw.write(String.valueOf(dp[N-1][M-1]));
+		}else {
+			bw.write(String.valueOf(dp[mustPos[0]][mustPos[1]] * dp[N - 1 - mustPos[0]][M - 1 - mustPos[1]]));
+		}
+		
+		bw.flush();
+		
+	}
+}

--- a/남우성/1차시/2631.java
+++ b/남우성/1차시/2631.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		int N = Integer.parseInt(br.readLine());
+		
+		int[] arr = new int[N];
+		for(int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(br.readLine());
+		}
+		
+		// 현재 index까지 가장 길게 찾을 수 있는 오름차순의 부분 수열 길이를 저장
+		// ex) 3 7 5 2 6 1 4 라면 
+		// arrLength[4]는 3~6까지 3 5 6이 가장 긴 부분 수열 => 3
+		// arrLength[6]은 3 4 혹은 2 4 혹은 1 4 만 가능 => 2
+		int[] arrLength = new int[N];
+		int result = 0;
+		
+		for(int i = 0; i < N; i++) {
+			arrLength[i] = 1;
+			for(int j = i-1; j >=0; j--) {
+				
+				// 검사하는 i 인덱스 기준 가장 긴 부분 수열 길이를 찾아서 저장
+				// 가장 긴 부분 수열을 result에 저장
+				if( arr[i] > arr[j]) {
+					arrLength[i] = Math.max(arrLength[i], arrLength[j] + 1);
+					result = Math.max(result, arrLength[i]);
+				}
+				
+			}
+		}
+		System.out.print(N - result); // 정렬 된 부분 말고 나머지 부분만 옮긴다고 생각하고 N - result가 정답
+	}
+}


### PR DESCRIPTION
# 실버 문제

## 문제 링크

- 문제 링크 : [10164 격자상의 경로](https://www.acmicpc.net/problem/10164)

## 시간 복잡도 및 공간 복잡도
- 메모리: 14,364 KB
- 시간: 108ms
- 분석한 시간복잡도: O(N * M) ← 입력값 그대로
    - 이유: 주어진 2차원 배열을 한 번 순회하면 정답 도출 가능

<br>

## 접근 방식
- 처음에는 굳이 DP로 안풀어도 수학적으로 계산할 수 있지 않나? 싶어서 계산해보려 했는데 수식이 딱히 생각이 안나서 포기

⇒ 풀이는 DP로 풀이 시도

## 문제 풀이 요약
- 먼저 N * M 크기의 경우의 수를 모두 구하기 위해 dp를 만들고, 계산
    - 만약 K가 없다면 단순히 `dp[N-1][M-1]` 정답
    - K가 있다면 중간에 반드시 K의 위치를 지나야됨
    
    ⇒ K까지 경우의 수 x k부터 끝까지 크기의 경우의 수로 계산
    
    (이때 굳이 k부터 끝까지를 계산하기 보다, 어짜피 위치가 중요한게 아니고 보드의 크기가 중요한 거니까 그 크기만큼 이미 계산한 식을 사용)
    
    ex) 만약 보드 크기가 (4,8)이고, k의 위치가 (1, 2)라고 한다면 
    
    dp[1][2] ~ dp[4][8]를 계산하는 건 불편한데 사실 이 계산이 그냥 dp[3][6]와 같으니 해당 값을 사용

- 사용한 알고리즘 및 자료구조
    - 단순 DP + 배열 방식 사용
    - 점화식 세우기 어렵지는 않았음: `dp[i][j] = dp[i-1][j] + dp[i][j-1];`

## 리뷰 요청 포인트
만약 보드 크기가 [5][6] 이렇게 주어졌을 때, 바로 수학적으로 계산은 불가능하겠죠..? 아마..?

<br>


# 골드 문제

## 문제 링크

- 문제 링크 : [2631 줄세우기](https://www.acmicpc.net/problem/2631)

## 시간 복잡도 및 공간 복잡도
- 메모리: 14,140KB
- 시간: 104ms
- 분석한 시간복잡도: O(N^2)
    - 이유: 가장 긴 부분 수열을 찾을 때 N기준 2중 for 문을 사용했음

<br>
<br>


## 접근 방식
- 처음 든 생각은 단순히 그리디하게 하나씩 옮기면 안되나? 였는데 생각해보니 최적의 방법이 아니었음
- 분류가 DP라서 DP로 어떻게 풀지 고민했는데, 답이 안나옴
    - 3 7 5 2 6 1 4가 있다고 하면
    - 3만 있을 때, 3 7일 때, 3 7 5 일 때, … 를 생각해봤는데 도저히 이전의 시행이 이후 시행에 활용되도록 점화식을 세울 수 없었음
- DP 생각하지 말고 그냥 어떻게 해야 최적으로 정렬 시킬 수 있을 지를 생각해봄
    - 전체 배열 중에 정렬된 가장 긴 부분을 찾고, 해당 부분 정렬을 기준으로 나머지 숫자들만 옮기면 되지 않을까 싶어서 그렇게 해결함
   

## 문제 풀이 요약
- 가장 긴 부분 수열의 길이를 찾음. 그럼 해당 부분은 움직일 필요가 없는 애들이고, 나머지 애들만 움직이면 되니까 N - (가장 긴 부분수열 길이)로 계산
    - 3 7 5 2 6 1 4라면 3 5 6이 가장 긴 부분 정렬 ⇒ 3 5 6은 고정하고 나머지 7, 2, 1, 4만 자리 맞춰서 이동시킨다고 생각 ⇒ 4회로 정렬가능

- 사용한 알고리즘 및 자료구조
    - DP 및 배열
    - DP는 가장 긴 부분 수열을 구할 때 arrLength 배열에서 사용함


## 리뷰 요청 포인트
찾아보니까 가장 긴 부분 수열을 찾을 때, 제 풀이처럼 2중 for문 돌리는 것 보다 binarySearch쓰면 O(NlogN)로 가능하더라고요! 관련해서 찾아보셔도 좋을 것 같습니다!


<br>




### 🫡 오늘도 고생하셨습니다!



