### PR TITLE
[1차시] 천보성 - 백준 2631, 10164

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>algorithm_daejeon6_hard</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/천보성/1차시/BOJ_10164.java
+++ b/천보성/1차시/BOJ_10164.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_10164 {
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		/*경우의 수 문제
+		 * 중간 거쳐야 하는 좌표까지의 경우의 수 * 중간부터 마지막 (n-1,n-1) 까지 경우의 수
+		*/
+		if(K != 0) {
+			int x = K/M;
+			int y = K%M;
+			
+			if(y != 0) x += 1;
+			if(y == 0) y += M;
+		
+			int pre = countRoute(x, y);
+			int post = countRoute(N-x+1, M-y+1);
+			System.out.println(pre * post);
+		}
+		else {
+			System.out.println(countRoute(N, M));
+		}
+	
+	}
+
+	private static int countRoute(int x, int y) {
+		int[][] dp = new int[x][y];
+		
+		for(int i=0;i<x;i++) {
+			dp[i][0] = 1;
+		}
+		for(int j=0;j<y;j++) {
+			dp[0][j] = 1;
+		}
+		for(int i=1;i<x;i++) {
+			for(int j=1;j<y;j++) {
+				dp[i][j] = dp[i-1][j] + dp[i][j-1];
+			}
+		}
+		
+		return dp[x-1][y-1];
+	}
+
+}

--- a/천보성/1차시/BOJ_2631.java
+++ b/천보성/1차시/BOJ_2631.java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ_2631 {
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in)); 
+		int N = Integer.parseInt(br.readLine());
+		
+		int[] arr = new int[N];
+		int[] dp = new int[N];
+		
+		for(int i=0;i<N;i++) {
+			arr[i] = Integer.parseInt(br.readLine());
+		}
+		
+		int max = 0;
+		
+		//LIS 알고리즘
+		for(int i=0;i<N;i++) {
+			dp[i] = 1; // 자기 자신 길이
+			for(int j=0;j<i;j++) {
+				if(arr[i] > arr[j]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+				}
+			}
+			max = Math.max(max, dp[i]);
+		}
+		
+		// 전체인원에서 LIS를 빼면 최솟값
+		System.out.println(N - max);
+	}
+}                        


### PR DESCRIPTION
# 실버문제

## 문제 링크
- 문제 링크 : (https://www.acmicpc.net/problem/10164)

## 시간 복잡도 및 공간 복잡도
- 메모리 : 14304kb
- 시간 : 104ms

<br>

## 접근 방식
> 문제를 읽고 수학 문제 길찾기를 떠올렸습니다.
특정한 구간을 무조건 지나칠 경우 (0,0) 에서 (x,y) 까지 가는 경우의 수, (x, y)에서 (n-1, n-1) 까지 가는 경우의 수의 곱을 생각했습니다.

## 문제 풀이 요약
> 경우의 수를 구하기 위해 dp를 활용


## 리뷰 요청 포인트
> 

## 기타 회고
> 


<br>
# 골드 문제

## 문제 링크
- 문제 링크 : (https://www.acmicpc.net/problem/2631)

## 시간 복잡도 및 공간 복잡도
- 메모리 : 14204kb
- 시간 : 124ms

<br>

## 접근 방식
> 입력 범위를 보니 완탐은 절대 불가능 -> 2^200
 알고리즘 분류가 정해져 있다 보니 dp로 생각이 꽂히는 경향이 있음..

## 문제 풀이 요약
> LIS 알고리즘을 활용, 증가하는 부분 수열을 제외하고 움직여야 하는 아이들.
총 인원수 - LIS 길이 = 최소로 움직여야 하는 횟수


## 리뷰 요청 포인트
> 

## 기타 회고
> 

### 🫡 오늘도 고생하셨습니다!



