### PR TITLE
[2차시] 남우성 - 백준 1325, 3584

### DIFF
--- a/남우성/2차시/1325.java
+++ b/남우성/2차시/1325.java
@@ -1,0 +1,78 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	private static List<List<Integer>> graph;
+	private static int[] results;
+	
+	public static void main(String[] args)throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		StringBuilder sb = new StringBuilder();
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		
+		graph = new ArrayList<>();
+		
+		
+		// graph에는 다음을 저장
+		// graph[1]: 1번 인덱스를 선택하면 연쇄적으로 해킹되는 index들을 저장
+		for(int i = 0; i <= N; i++) {
+			graph.add(new ArrayList<>());
+		}
+		
+		for(int i = 0; i < M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int A = Integer.parseInt(st.nextToken());
+			int B = Integer.parseInt(st.nextToken());
+			
+			graph.get(B).add(A);
+		}
+		
+		
+		int maxCount = 0;
+		Deque<Integer> bfs = new ArrayDeque<>();
+		results = new int[N+1];
+		
+		for(int i = 1; i <= N; i++) {
+			
+			boolean[] isVisited = new boolean[N+1]; // 방문처리를 위함
+			
+			bfs.offer(i);
+			isVisited[i] = true;
+
+			while(!bfs.isEmpty()) {
+				int now = bfs.poll();
+				results[i]++;
+				
+				for(int item: graph.get(now)) {
+					if(!isVisited[item]) {
+						bfs.offer(item);
+						isVisited[item] = true;
+					}
+				}
+			}
+			maxCount = Math.max(maxCount, results[i]);
+		}
+		
+		for(int i = 1; i <= N; i++) {
+			if (results[i] == maxCount) {
+				sb.append(i).append(" ");
+			}
+		}
+		bw.write(sb.toString());
+		bw.flush();
+	}
+}

--- a/남우성/2차시/3584.java
+++ b/남우성/2차시/3584.java
@@ -1,0 +1,57 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args)throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int testCase = 0; testCase < T; testCase++) {
+			int N = Integer.parseInt(br.readLine());
+			
+			int[] tree = new int[N+1]; //각 index 마다의 부모를 저장
+			
+			StringTokenizer st;
+			for(int i = 0; i < N-1; i++) {
+				st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				
+				tree[b] = a;
+			}
+			
+			st = new StringTokenizer(br.readLine());
+			int node1 = Integer.parseInt(st.nextToken());
+			int node2= Integer.parseInt(st.nextToken());
+			
+			Set<Integer> parents = new HashSet<>();
+			
+			//먼저 node1 자신 및 자신의 부모들을 parents에 저장
+			int now = node1;
+			
+			while(now != 0) {
+				parents.add(now);
+				now = tree[now];
+			}
+			
+			// node2의 부모들을 parents에 저장해 나가는데 처음 동일한 item이 들어가면 해당 index가 공통조상
+			now = node2;
+			int result = 0;
+			
+			while(now != 0) {
+				if(!parents.add(now)) {
+					result = now;
+					break;
+				}
+				now = tree[now];
+			}
+			sb.append(result).append("\n");
+		}
+		System.out.print(sb);
+	}
+}


### PR DESCRIPTION
# 실버 문제

## 문제 링크

- 문제 링크 : [1325 효율적인 해킹](https://www.acmicpc.net/problem/1325)

## 시간 복잡도 및 공간 복잡도
- 메모리: 307,208KB
- 시간: 10660ms
- 분석한 시간복잡도: O(N * M)
    - 이유: N번 순회하면서 그래프 따라가다보면 최대 M번까지 순회될 수 있음

<br>

## 접근 방식
- 처음에 각 index 마다 bfs로 풀었음
    - 각 index마다 자신과 연결된 노드들을 queue에 넣고 bfs로 탐색해 나가면서 전체 count를 계산
    
    ⇒ 시간 초과….
    
    - 아마 최소 O(N * M) 이상의 시간 복잡도를 가지는데, 이 값이 최소 10억이라 시간초과 난 듯
    - 더 효율적인 방식 고민

- 배열을 하나 선언해놓고 각 index마다 연쇄되는 컴퓨터의 총 개수를 저장해 놓을 까도 생각해 봤는데… 이게 가능할 지 의문…
    - ex) 1번 → 2,3,4 연쇄, 2번 → 3,4,5 연쇄인 상황에서 10 → 1,2라면 3번이랑 4번이 2번씩 겹치게 되니까… 이런 중복 방지를 해야 하는데 가능하려나..

## 문제 풀이 요약
- 문제 분석 및 나의 풀이
    - 각 index마다 bfs로 그래프 탐색
- 사용한 알고리즘 및 자료구조
    - bfs + deque
- 시간초과의 경우 변수들을 static으로 선언하니 해결 되었음...


## 기타 회고
- 이 문제는 다시 풀고 싶지 않습니다……

<br>

<br>


# 골드 문제

## 문제 링크

- 문제 링크 : [3584 가장 가까운 공통 조상](https://www.acmicpc.net/problem/3584)

## 시간 복잡도 및 공간 복잡도
- 메모리: 25,688 KB
- 시간: 228 ms
- 분석한 시간복잡도: O(N)
    - 이유
        - 먼저 node1의 부모를 탐색할 때, 최악의 경우는 리프 노드라면 N만큼 탐색
        - node2도 마찬가지
        - ⇒ 2N만큼 걸리니 O(N)
        - hashset의 add는 O(1)이므로 별도의 시간복잡도 필요 X

<br>

## 접근 방식
- 딱히 별다른 고민은 하지 않고 단순 그래프 구현으로 풀 수 있을 거라고 생각함

## 문제 풀이 요약
- 문제 분석 및 나의 풀이
    - 먼저 tree이므로 무조건 모든 node는 부모가 1개
    
    ⇒ 1차원 배열을 선언하고 각자 자신의 node의 부모를 저장하게 함
    
    - 이후 공통 조상을 찾기 위해 set 자료구조를 사용
    - node1부터 자기 자신과 부모들을 set에 넣어둠
    - 이후 node2도 자기 자신과 부모들을 set에 넣는데, 처음 공통된 item이 존재하면 해당 item을 공통조상으로 간주


- 사용한 알고리즘 및 자료구조
    - 부모 저장을 위해 array 사용
    - 공통 조상 탐색을 위해 set 사용
    - 따로 별다른 알고리즘은 사용 x


## 기타 회고
- 생각해보니 공통 조상 판별할 때 굳이 set을 안쓰고 단순히 boolean 배열 선언해 놓고 true, flase로 판단해도 됐네요…
    - 시간 복잡도 차이는 없어서 선택 사항이긴 한데, 굳이굳이 set을 쓸 필요는 없을 것 같네요

<br>



### 🫡 오늘도 고생하셨습니다!



