### PR TITLE
[3차시] 안도형 21758번, 1138번

### DIFF
--- a/안도형/3차시/BOJ_1138.java
+++ b/안도형/3차시/BOJ_1138.java
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        int[] arr = Arrays.stream(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        int[] answer = new int[arr.length];
+        int index = 0;
+        while(index < arr.length) {
+            int count = arr[index];
+            for (int i = 0; i < N; i++) {
+                if(answer[i] != 0) continue;
+
+                if (count > 0) {
+                    count--;
+                }else {
+                    answer[i] = index + 1;
+                    break;
+                }
+            }
+            index++;
+        }
+        for (int val : answer) {
+            System.out.print(val + " ");
+        }
+    }
+
+
+}

--- a/안도형/3차시/BOJ_21758.java
+++ b/안도형/3차시/BOJ_21758.java
@@ -1,0 +1,46 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+        int[] honey = new int[N];
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            honey[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] prefix = new int[N];
+        prefix[0] = honey[0];
+        for (int i = 1; i < N; i++) {
+            prefix[i] = prefix[i - 1] + honey[i];
+        }
+
+        int max = 0;
+
+        for (int i = 1; i < N - 1; i++) {
+            int bee1 = prefix[N - 1] - honey[0] - honey[i];
+            int bee2 = prefix[N - 1] - prefix[i];
+            max = Math.max(max, bee1 + bee2);
+        }
+
+        for (int i = 1; i < N - 1; i++) {
+            int bee1 = prefix[N - 2] - honey[i];
+            int bee2 = prefix[i - 1];
+            max = Math.max(max, bee1 + bee2);
+        }
+
+        for (int i = 1; i < N - 1; i++) {
+            int bee1 = prefix[i] - honey[0];
+            int bee2 = prefix[N - 1] - prefix[i - 1] - honey[N - 1];
+            max = Math.max(max, bee1 + bee2);
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
# 실버 문제
## 복잡도

**시간 복잡도:** `O(N²)`, **공간 복잡도:** `O(N)` , 메모리 16164KB , 시간 : 124ms

## 접근 방식
작은 키부터 순차적으로 배치해야 한다고 판단.
키가 작은 사람부터 배치하므로 항상 자기보다 큰 사람의 조건만 고려하면 됩니다.

키가 1인 사람부터 시작하여, arr[i]만큼 빈자리를 스킵하며 빈 자리를 찾고, 그 자리에 사람의 키(i+1)을 대입한다.

줄은 한 번 정해지면 뒤집거나 바꾸지 않기 때문에, 이렇게 작은 키 순서대로 처리하면 충돌이나 에러가 발생
 
## 문제 풀이
- arr[0] = k → 왼쪽에 키 큰 사람 k명 있어야 함

- answer[0..N-1] 중 아직 비어 있는 자리만 보면서:

- k개의 빈칸을 건너뜀

- k == 0이면 현재 자리에 배치

## 회고
- 문제 자체를 이해하는데 어려움을 겪었다. 실제 코테에서도 해석하는데 난해한 문제가 출제되기 때문에 때문에 좋은 문제라고 생각되어진다.


# 골드 문제

## 복잡도

**시간 복잡도:** `O(N)`, **공간 복잡도:** `O(N)` , 메모리 25368KB , 시간 : 264ms

## 접근 방식

벌들이 좌측에 있을 때와 우측에 있을 때만 계산 굳이 계속 벌의 위치를 옮길 때 마다 계산해 줄필요 없다 판단 누적 합 사용 

벌과 벌통의 거리가 최대한 거야한다고 판단 하지만 틀렸다. 중앙에 벌집이 있을 때 필요 없다고 판단이 되었지만

추가로 gpt에게 물어봐 벌들이 좌 우측에 하나 씩 있을 때 판단을 해줘야한다는 것을 알게 되었다.

## 문제 풀이

- `honey[]`: 각 칸에 들어 있는 꿀의 양을 저장하는 배열
    - 입력값을 그대로 저장
- `prefix[]`: 꿀의 누적합을 저장하는 배열
    - `prefix[i] = honey[0] + honey[1] + ... + honey[i]`
- 세 가지 케이스로 나누어 계산:
    - Case 1: 벌통 오른쪽 끝, 벌1 왼쪽 고정, 벌2가 중간 이동
    - Case 2: 벌통 왼쪽 끝, 벌1 오른쪽 고정, 벌2가 중간 이동
    - Case 3: 벌1 왼쪽 끝, 벌2 오른쪽 끝, 벌통이 중간 이동
- 각 케이스에 대해 `prefix` 배열로 구간합을 빠르게 계산하여 최대값 추출

## 회고

- 어느 정도 논리 상 부족한 부분이 보인다면 한번 시도해보자


<br>

### 🫡 오늘도 고생하셨습니다!



