### PR TITLE
[4차시] 박정훈 15954번 인형들, 12919번 A와 B 2

### DIFF
--- a/박정훈/4차시/BOJ_12919.java
+++ b/박정훈/4차시/BOJ_12919.java
@@ -1,0 +1,73 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ_12919 {
+	static boolean isFind;
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder S = new StringBuilder(br.readLine());
+		StringBuilder T = new StringBuilder(br.readLine());
+		StringBuilder temp = new StringBuilder(T);
+		
+		// T의 첫 글자가 A, 마지막 글자가 A인 경우
+		if(T.charAt(0) == 'A' && T.charAt(T.length() - 1) == 'A') {
+			minusA(S, temp);
+		} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'B') { //T의 첫 글자가 B, 마지막 글자가 B인 경우
+			minusB(S, temp);
+		} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'A') { //T의 첫 글자가 B, 마지막 글자가 A인 경우
+			minusA(S, temp);
+			minusB(S, T);
+		} // 첫 글자가 A, 마지막 글자가 B인 경우는 만들 수 없음
+		
+		System.out.print(isFind ? 1 : 0);
+	}
+	
+	public static void minusA(StringBuilder S, StringBuilder T) {
+		if(!isFind && S.length() < T.length()) { // 아직 발견 못 한 경우에만
+			T.deleteCharAt(T.length() - 1); // 마지막 글자 지우기
+			if(S.length() == T.length() && S.toString().equals(T.toString())) { // 비교
+				isFind = true;
+				return;
+			} else {
+				StringBuilder temp = new StringBuilder(T);
+				// T의 첫 글자가 A, 마지막 글자가 A인 경우
+				if(T.charAt(0) == 'A' && T.charAt(T.length() - 1) == 'A') {
+					minusA(S, temp);
+				} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'B') { //T의 첫 글자가 B, 마지막 글자가 B인 경우
+					minusB(S, temp);
+				} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'A') { //T의 첫 글자가 B, 마지막 글자가 A인 경우
+					minusA(S, temp);
+					minusB(S, T);
+				} else { // 첫 글자가 A, 마지막 글자가 B인 경우는 만들 수 없음
+					return;
+				}
+			}
+		}
+	}
+	
+	public static void minusB(StringBuilder S, StringBuilder T) {
+		if(!isFind && S.length() < T.length()) { // 아직 발견 못 한 경우에만
+			T.reverse(); // 문자열 뒤집기
+			T.deleteCharAt(T.length() - 1); // 마지막 글자 지우기
+			if(S.length() == T.length() && S.toString().equals(T.toString())) { // 비교
+				isFind = true;
+				return;
+			} else {
+				StringBuilder temp = new StringBuilder(T);
+				// T의 첫 글자가 A, 마지막 글자가 A인 경우
+				if(T.charAt(0) == 'A' && T.charAt(T.length() - 1) == 'A') {
+					minusA(S, temp);
+				} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'B') { //T의 첫 글자가 B, 마지막 글자가 B인 경우
+					minusB(S, temp);
+				} else if(T.charAt(0) == 'B' && T.charAt(T.length() - 1) == 'A') { //T의 첫 글자가 B, 마지막 글자가 A인 경우
+					minusA(S, temp);
+					minusB(S, T);
+				} else { // 첫 글자가 A, 마지막 글자가 B인 경우는 만들 수 없음
+					return;
+				}
+			}
+		}
+	}
+}

--- a/박정훈/4차시/BOJ_15954.java
+++ b/박정훈/4차시/BOJ_15954.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_15954 {
+	
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		st = new StringTokenizer(br.readLine());
+		int[] favorite = new int[N];
+		double minSD = Double.MAX_VALUE; //최소 표준편차
+		
+		// 입력
+		for(int i = 0; i < N; i++) {
+			favorite[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		//탐색
+		for(int i = K; i <= N; i++) { // K개 이상 선택
+			for(int start = 0; start <= N - i; start++) {
+				int end = start + i;
+				int sum = 0;
+				
+				// 합계
+				for(int j = start; j < end; j++) {
+					sum += favorite[j];
+				}
+				
+				double m = (double) sum / i; //평균
+				
+				// 분산
+				double vSum = 0;
+				for(int j = start; j < end; j++) {
+					vSum += Math.pow(favorite[j] - m, 2);
+				}
+				double v = vSum / i;
+				
+				//표준편차
+				minSD = Math.min(minSD, Math.sqrt(v));
+			}
+		}
+		
+		System.out.print(minSD);
+	}
+}


### PR DESCRIPTION
# 실버 문제

## 문제 링크

- 문제 링크 : [15954번 인형들](https://www.acmicpc.net/problem/15954)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(N*(N-K)) => O(N^2)
+ 우성님께서 말씀하신대로 sum과 분산을 구하는 과정에서 O(N)이 추가되기 때문에 O(N^3)이 맞네요! 감사합니다
<img width="929" height="68" alt="image" src="https://github.com/user-attachments/assets/7fedc349-37d6-4ac4-b184-95ae8f15d049" />


<br>

## 접근 방식
가능한 범위 내의 표준 편차를 구하며 최소값 갱신


## 문제 풀이 요약
- i(K 이상)개를 선택할 때의 경우를 순차적으로 탐색
- 시작점(start)부터 start + i까지의 범위 내에 있는 수의 표준 편차를 차례로 구하며 갱신


## 리뷰 요청 포인트
X

## 기타 회고
- 문제 풀이 자체는 크게 어렵지 않았음
- 다만, 문제를 이해를 못 하고 처음엔 인형을 오름차순으로 정렬함
- K 값도 고정인 줄 알았음

<br>

# 골드 문제

## 문제 링크

- 문제 링크 : [12919번 A와 B 2](https://www.acmicpc.net/problem/12919)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(2^N)
<img width="932" height="73" alt="image" src="https://github.com/user-attachments/assets/ca447da5-481c-40ef-b98d-a71fc55b6a24" />


<br>

## 접근 방식
S -> T가 아닌 T에서 경우의 수를 나누어 연산하여 S가 될 수 있는 지 검사


## 문제 풀이 요약
총 4가지의 경우가 존재
- T의 첫 글자가 A, 마지막 글자가 A인 경우
   - 마지막 글자(A) 빼기
- T의 첫 글자가 B, 마지막 글자가 B인 경우
   - 문자열을 뒤집은 후, 마지막 글자(B) 빼기 
- T의 첫 글자가 B, 마지막 글자가 A인 경우
   - 마지막 글자(A)를 빼는 경우와 뒤집은 후 마지막 글자(B)를 빼는 경우 두 가지 모두 탐색
- 첫 글자가 A, 마지막 글자가 B인 경우
   - 만들 수 없음

위 연산을 재귀 호출하며 글자의 수가 같아 졌을 때, 문자열이 같은 지 비교
같은 경우 isFind 함수를 true 수정해 다음 연산을 더 이상 수행하지 않게 함

## 리뷰 요청 포인트
시간복잡도를 줄일 수 있는 방법

## 기타 회고
문자열이 같은 지 비교할 때, 굳이 S와 T의 길이가 같은 지를 AND 연산으로 검사한 이유는 길이가 다를 때에도 equals()로 매번 비교하는 것보다 길이가 다를 땐 equals()를 호출하지 않게 하는 것이 시간을 조금이라도 줄 일 수 있지 않을까 했는데 두 코드 모두 제출했을 때 시간의 차이는 없네요 -> 찾아보니 줄일 수는 있으나 미세해서 가독성이 더 중요하다네요

<br>

### 🫡 오늘도 고생하셨습니다!



