### PR TITLE
[6차시] 남우성 - BOJ_2655

### DIFF
--- a/남우성/6차시/2665.java
+++ b/남우성/6차시/2665.java
@@ -1,0 +1,69 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class Main {
+	
+	static class Pos{
+		int x;
+		int y;
+
+		public Pos(int x, int y) {
+			super();
+			this.x = x;
+			this.y = y;
+		}
+	}
+	
+	static int[] dx = {0, 0, 1, -1};
+	static int[] dy = {1, -1, 0, 0};
+	
+	public static void main(String[] args) throws Exception{
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int N = Integer.parseInt(br.readLine());
+		
+		int[][] board = new int[N][N];
+		int[][] weights = new int[N][N];
+		for(int i = 0; i < N; i++) {
+			String[] line = br.readLine().split("");
+			for(int j = 0; j < N; j++) {
+				board[i][j] = Integer.valueOf(line[j]);
+				weights[i][j] = Integer.MAX_VALUE;
+			}
+		}
+		
+		Deque<Pos> deque = new ArrayDeque<>();
+		deque.add(new Pos(0, 0));
+		weights[0][0] = 0;
+		while(!deque.isEmpty()) {
+			Pos now = deque.poll();
+			
+			for(int i = 0; i < 4; i++) {
+				int nx = now.x + dx[i];
+				int ny = now.y + dy[i];
+				
+				if(nx >= 0 && nx < N && ny >= 0 && ny < N) {
+					
+					if(board[nx][ny] == 1) { //흰 방
+						if(weights[nx][ny] > weights[now.x][now.y]) { // 더 짧은 경로 존재
+							weights[nx][ny] = weights[now.x][now.y];
+							deque.add(new Pos(nx, ny));
+						}
+					} else { //검은 방
+						if(weights[nx][ny] > weights[now.x][now.y] + 1) { // 더 짧은 경로 존재
+							weights[nx][ny] = weights[now.x][now.y] + 1;
+							deque.add(new Pos(nx, ny));
+						}
+					}
+					
+				}
+			}
+			
+		}
+		
+		System.out.print(weights[N-1][N-1]);
+	}
+}


### PR DESCRIPTION
## 문제 링크

- 문제 링크 : [2665 미로만들기](https://www.acmicpc.net/problem/2665)

## 시간 복잡도 및 공간 복잡도
<img width="1031" height="33" alt="image" src="https://github.com/user-attachments/assets/d07373b1-c9c1-473e-9e1b-c869299f6eb6" />

- 분석한 시간복잡도: O(N^2)
- 이유: bfs를 돌면서 N^2 배열 탐색. 근데 N^2이 맞나..?

<br>

## 접근 방식
- 가장 처음 떠오른 풀이는 bfs

⇒ queue에 가능한 경로를 넣어가면서 진행하고, 검은 색일 경우 count를 isVisted에 저장해가며 전개 ⇒ 맞막에 최소 count를 출력

⇒ O(N^2) 시간복잡도를 가짐. 근데 N이 50이하라 충분히 가능할 것이라 생각이 들긴 함

- 최적화 방안 고민하다가 다익스트라를 사용하면 O(NlogN)으로 줄일 수 있을 거 같았음
    - 각 연속된 큰 흰 방을 크게 하나의 노드로 인식하고, 각 노드별로 이동할 때 허물어야할 검은 방의 개수가 weight로 간주한다면 탐색해가는 과정을 O(NlogN으로 처리 가능)
    - 근데 어짜피 각 노드별 연결될 수 있는 weight를 계산하려면 dfs나 bfs를 적용해야 하지 않나..? 그럼 이게 더 비효율적인 거 같은데..?

⇒ bfs로 풀이


## 문제 풀이 요약
- 문제 분석 및 나의 풀이
    - bfs로 풀이
    - 사방탐색을 전개하면서 weight가 더 낮아지는 경우 queue에 삽입 후 탐색
- 사용한 알고리즘 및 자료구조
    - bfs, 배열
- 이유
    - 이 문제에서는 최소거리를 찾는 문제라서 dfs보다 bfs가 훨씬 효율적일 거 같았음


## 리뷰 요청 포인트
> 피드백 받고싶은 부분을 작성해주세요.

## 기타 회고
> 자율적으로 본인의 회고를 작성해주세요.


<br>

### 🫡 오늘도 고생하셨습니다!



