### PR TITLE
[6차시] 안도형 - 2665번 미로 만들기

### DIFF
--- a/안도형/6차시/BOJ_2665.java
+++ b/안도형/6차시/BOJ_2665.java
@@ -47,7 +47,7 @@ public class BOJ_2665 {
                 int nr = p.r + dr[d];
                 int nc = p.c + dc[d];
 
-                if (nr < 0 || nr >= N || nc < 0 || nc >= N) continue;
+                if (nr >= 0 && nr < N && nc >= 0 && nc < N) continue;
 
                 int cost = dist[p.r][p.c] + (map[nr][nc] == 0 ? 1 : 0);
 

--- a/안도형/6차시/BOJ_2665.java
+++ b/안도형/6차시/BOJ_2665.java
@@ -1,0 +1,66 @@
+package BOJ;
+
+import java.io.*;
+import java.util.*;
+
+public class BOJ_2665 {
+    static int N;
+    static int[][] map, dist;
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    static class Pair {
+        int r, c;
+        Pair(int r, int c) {
+            this.r = r; this.c = c;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        map = new int[N][N];
+        dist = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            String row = br.readLine();
+            for (int j = 0; j < N; j++) {
+                map[i][j] = row.charAt(j) - '0';
+                dist[i][j] = Integer.MAX_VALUE;
+            }
+        }
+
+        bfs();
+
+        System.out.println(dist[N-1][N-1]);
+    }
+
+    static void bfs() {
+        Deque<Pair> dq = new ArrayDeque<>();
+        dq.add(new Pair(0, 0));
+        dist[0][0] = 0;
+
+        while (!dq.isEmpty()) {
+            Pair p = dq.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nr = p.r + dr[d];
+                int nc = p.c + dc[d];
+
+                if (nr < 0 || nr >= N || nc < 0 || nc >= N) continue;
+
+                int cost = dist[p.r][p.c] + (map[nr][nc] == 0 ? 1 : 0);
+
+                if (cost < dist[nr][nc]) {
+                    dist[nr][nc] = cost;
+                    if (map[nr][nc] == 1) {
+                        dq.addFirst(new Pair(nr, nc));
+                    } else {
+                        dq.addLast(new Pair(nr, nc));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/안도형/6차시/BOJ_2665.java
+++ b/안도형/6차시/BOJ_2665.java
@@ -9,14 +9,12 @@ public class BOJ_2665 {
     static int[] dr = {-1, 1, 0, 0};
     static int[] dc = {0, 0, -1, 1};
 
-
     static class Pair {
         int r, c;
         Pair(int r, int c) {
             this.r = r; this.c = c;
         }
     }
-
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         N = Integer.parseInt(br.readLine());

--- a/안도형/6차시/BOJ_2665.java
+++ b/안도형/6차시/BOJ_2665.java
@@ -9,6 +9,7 @@ public class BOJ_2665 {
     static int[] dr = {-1, 1, 0, 0};
     static int[] dc = {0, 0, -1, 1};
 
+
     static class Pair {
         int r, c;
         Pair(int r, int c) {


### PR DESCRIPTION
## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/2665)

## 시간 복잡도 및 공간 복잡도
<html>
<body>
<!--StartFragment-->
메모리 | 시간 | 시간 복잡도 | 공간 복잡도
-- | -- | -- | --
14328KB | 104ms | O(N^2) | O(N^2)


<!-- notionvc: d5cd7bf9-30ed-4970-b8f0-9f7adc27835a --><!--EndFragment-->
</body>
</html>

<br>

## 접근 방식
- 미로 가장 적은 흑색 칸을 백색 칸으로 바꿔 미로를 탈출해야 합니다. -> 백색 = 0, 흑색 = 1 비용 합이 가장 적은 길을 만들자
- bfs로 구현해 현재까지 온 길이 비용이 더 적은 것을 담아 둔다면 
- 마지막엔 값이 가장 작은 것이 나올거라고 판단했습니다.


## 문제 풀이 요약
- 각 좌표의 최소 벽 부순 횟수(dist)를 Integer.MAX_VALUE로 초기화함.
- 시작점 (0,0)의 dist를 0으로 설정.
- 덱에서 좌표를 꺼내, 4방향으로 이동 시도. 흰 방이면 비용 0 → 덱 앞에 추가
- 검은 방(0)이면 비용 1 → 덱 뒤에 추가
- 이미 저장된 dist[nr][nc]보다 더 적은 비용이면 갱신
## 기타 회고
- 순탄하게 풀었습니다.


<br>

### 🫡 오늘도 고생하셨습니다!



