### PR TITLE
[8차시] 천보성 - BOJ_13335, BOJ_11559

### DIFF
--- a/천보성/8차시/BOJ_11559.java
+++ b/천보성/8차시/BOJ_11559.java
@@ -1,0 +1,97 @@
+import java.io.*;
+import java.util.*;
+
+
+public class BOJ_11559 {
+
+    static int[] dx = {-1,1,0,0};
+    static int[] dy = {0,0,-1,1};
+    static char[][] map;
+    static boolean[] checkExplode;  // 해당 열에서 폭발이 있었는지 확인 하는 배열
+    static boolean checkEnd;        // 게임이 끝나는 지 확인
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        map = new char[12][6];
+
+        for(int i=0;i<12;i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        int answer = -1;
+
+        while(!checkEnd) {
+            answer++;
+            checkEnd = true;
+            checkExplode = new boolean[6];
+
+            for(int i=11;i>=0;i--) {
+                for(int j=0;j<6;j++) {
+                    if(map[i][j] != '.') {
+                        explode(map[i][j], i, j);
+
+                    }
+                }
+            }
+
+            for(int i=0;i<6;i++) {
+                if(checkExplode[i]) {
+                    fallDown(i);
+                }
+            }
+        }
+        System.out.println(answer);
+
+    }
+
+    // bfs로 연결된 같은 문자 세기
+    public static void explode(char color, int x, int y) {
+        Queue<int[]> queue = new LinkedList<>();
+        boolean[][] visited = new boolean[12][6];
+        ArrayList<int[]> list = new ArrayList<>();     // 같은 문자의 위치를 저장하는 리스트
+
+        queue.add(new int[] {x, y});
+        visited[x][y] = true;
+
+        while(!queue.isEmpty()) {
+            int[] now = queue.poll();
+            list.add(now);
+
+            for(int i=0;i<4;i++) {
+                int nextX = now[0] + dx[i];
+                int nextY = now[1] + dy[i];
+
+                if(nextX < 0 || nextY < 0 || nextX >= 12 || nextY >= 6 || visited[nextX][nextY]) continue;
+                if(map[nextX][nextY] == color) {
+                    visited[nextX][nextY] = true;
+                    queue.add(new int[] {nextX, nextY});
+                }
+            }
+        }
+
+        //리스트 사이즈가 4 이상이면 폭발
+        if(list.size() >= 4) {
+            checkEnd = false;                     // 한번이라도 폭발이 있다면 게임은 안끝났음
+            for(int[] point : list) {
+                map[point[0]][point[1]] = '.';    // 해당 위치를 . 으로 초기화
+                checkExplode[point[1]] = true;    // 해당 열에서 폭발 있었다고 체크
+            }
+        }
+    }
+
+    // 폭발로 생긴 빈공간을 채우는 메서드
+    public static void fallDown(int y) {
+        int index = 11;
+
+        for(int i=11;i>=0;i--) {
+            if(map[i][y] != '.') {
+                map[index--][y] = map[i][y];
+            }
+        }
+        while(index >= 0) {
+            map[index--][y] = '.';
+        }
+
+    }
+}

--- a/천보성/8차시/BOJ_13335.java
+++ b/천보성/8차시/BOJ_13335.java
@@ -1,0 +1,60 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ_13335 {
+    static class Truck{
+        int weight;
+        int time;
+
+        Truck(int weight, int time){
+            this.weight = weight;
+            this.time = time;
+        }
+    }
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int w = Integer.parseInt(st.nextToken());
+        int L = Integer.parseInt(st.nextToken());
+
+        int[] weights = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for (int i=0;i<n;i++){
+            weights[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Queue<Truck> queue = new LinkedList<>();    // 트럭이 올라갈 다리
+        int index = 0;                              //  다리에 올라갈 트럭의 인덱스
+        int time = 0;                               // 총 진행 시간
+        int total = 0;                             // 다리에 올라간 트럭들의 무게 합
+
+        while(index < n){
+            time++;                                 // 1초씩 진행
+            if(!queue.isEmpty()){
+                Truck first = queue.peek();
+                if(time - first.time >= w){         // 다리 가장 앞 트럭의 시간 비교 후 빼기
+                    total -= first.weight;
+                    queue.poll();
+                }
+            }
+
+            if (queue.size() >= w) continue;         // 다리가 꽉 찼다면 continue
+
+            if(total + weights[index] <= L){
+                queue.add(new Truck(weights[index], time));      // 다음 트럭이 들어 올 수 있으면 넣기
+                total += weights[index++];
+            }
+
+        }
+
+
+        // 다리에 올라가 있는 마지막 트럭만 건너면 끝
+        while(queue.size() > 1){
+            queue.poll();
+        }
+
+        System.out.println(queue.poll().time + w);
+    }
+}


### PR DESCRIPTION
# 실버문제 BOJ_13335 트럭

## 문제 링크

- 문제 링크 : (https://www.acmicpc.net/problem/13335)

## 시간 복잡도 및 공간 복잡도
- <img width="1016" height="28" alt="image" src="https://github.com/user-attachments/assets/d62b33a6-78eb-467b-8350-cb9a69b5d96b" />

<br>

## 접근 방식
처음엔 1초씩 진행하는 것이 아니라 통째로 진행하고 싶었습니다.
 하지만 트럭의 무게와 위치를 동시에 처리하는 것에 어려움을 느껴 1초씩 진행하는 것으로 변경했습니다.
 순서가 변경될 일이 없고 다리에 먼저 들어오는 것이 먼저 나가기에 큐를 사용


## 문제 풀이 요약
>
- 트럭이 올라갈 다리를 큐로 구현
- 큐에 들어가 있는 사이즈가 다리 위의 트럭 수
- 마지막 트럭은 1초씩 진행할 필요가 없음, 마지막 트럭의 입장 시간에 다리 길이를 더하면 끝!

## 리뷰 요청 포인트
>

## 기타 회고
 실버문제 치고 굉장히 어렵네요..
알고리즘 분류를 가리니깐 효과가 좀 있는 것 같습니다.


<br>

# 골드문제 BOJ_11559 puyo puyo

## 문제 링크

- 문제 링크 : (https://www.acmicpc.net/problem/11559)

## 시간 복잡도 및 공간 복잡도
- 
<img width="1032" height="33" alt="image" src="https://github.com/user-attachments/assets/87e1c0ed-a444-4ac3-bf5a-4c7c40cd6431" />


<br>

## 접근 방식
이 문제는 보자마자 구현 문제라는 것을 깨달았습니다.
4개 이상 모여서 터질 블럭들은 dfs나 bfs로 처리해야 하고
위에서 아래로 떨어지는 로직을 구현하면 끝


## 문제 풀이 요약
> 
- BFS를 활용하여 4개 이상 모여있는 블럭들 찾기
- 그 과정에서 블럭들의 위치를 ArrayList에 저장 후 . 으로 초기화
- 변동이 생긴 열을 체크 후 밑으로 당김

## 리뷰 요청 포인트
>

## 기타 회고
오히려 실버 문제가 어려웠던 것 같습니다.
bfs나 dfs 섞는 문제는 너무 익숙해 진 것 같아요

<br>

### 🫡 오늘도 고생하셨습니다!



