### PR TITLE
[8차시] 박정훈 - BOJ_13335, BOJ_11559

### DIFF
--- a/박정훈/8차시/BOJ_11559.java
+++ b/박정훈/8차시/BOJ_11559.java
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BOJ_11559 {
+	static int[] dx = new int[] {0, 1, 0, -1};
+	static int[] dy = new int[] {-1, 0, 1, 0};
+	static List<int[]> posList = new ArrayList<>();
+	
+	public static void main(String[] args) throws IOException{
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    char[][] field = new char[12][6];
+	    for(int i = 0; i < 12; i++) {
+	    	field[i] = br.readLine().toCharArray();
+	    }
+	    int chain = 0; // 연쇄 횟수
+	    boolean isBomb = false; // 이번 턴에 터졌는 지
+	
+	    while(true) {
+	    	for(int y = 11; y >= 0; y--) { // 아래로 내려오기 때문에 아래부터
+	    		for(int x = 0; x < 6; x++) {
+	    			if(field[y][x] != '.') { // 뿌요라면
+	    				posList.clear(); // 리스트 초기화
+	    				boolean[][] visited = new boolean[12][6]; // 방문 초기화
+	    				visited[y][x] = true;
+	    				posList.add(new int[] {x, y});
+	    				// 같은 색 찾기
+	    				dfs(x, y, field[y][x], field, visited);
+	    				
+	    				// 인접한 같은 색이 4개 이상
+	    				if(posList.size() >= 4) {
+	    					isBomb = true;
+	    					for(int i = 0; i < posList.size(); i++) {
+	    						int[] pos = posList.get(i);
+	    						field[pos[1]][pos[0]] = '.';
+	    					}
+	    				}
+	    			}
+	    		}
+	    	}
+	    	// 터진 게 있다면
+	    	if(isBomb) {
+	    		down(field); // 밑으로 내리기
+	    		chain++; // 연쇄 +1
+	    		isBomb = false;
+	    	} else { // 터진 게 없다면 종료
+	    		break;
+	    	}
+	    }
+	    System.out.print(chain);
+	}
+	
+	public static void dfs(int x, int y, char c, char[][] field, boolean[][] visited) {
+		for(int i = 0; i < 4; i++) {
+			int nx = x + dx[i];
+			int ny = y + dy[i];
+			
+			//범위 밖이거나 방문한 곳
+			if(nx < 0 || nx > 5 || ny < 0 || ny > 11 || visited[ny][nx]) continue;
+			
+			//탐색하는 색과 동일
+			if(field[ny][nx] == c) {
+				visited[ny][nx] = true;
+				posList.add(new int[] {nx, ny});
+				dfs(nx, ny, c, field, visited);
+			}
+		}
+	}
+	
+	public static void down(char[][] field) {
+		for(int x = 0; x < 6; x++) {
+			for(int y = 11; y >= 0; y--) { //아래 칸부터 탐색
+				if(field[y][x] == '.') { // 빈 칸이라면
+					for(int p = y - 1; p >= 0; p--) { // 내릴 뿌요 찾기
+						if(field[p][x] != '.') { // 뿌요라면
+							field[y][x] = field[p][x]; //내리기
+							field[p][x] = '.';
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/박정훈/8차시/BOJ_13335.java
+++ b/박정훈/8차시/BOJ_13335.java
@@ -1,0 +1,54 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_13335 {
+
+	public static void main(String[] args) throws IOException{
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    StringTokenizer st = new StringTokenizer(br.readLine());
+	    int n = Integer.parseInt(st.nextToken());
+	    int w = Integer.parseInt(st.nextToken());
+	    int L = Integer.parseInt(st.nextToken());
+	    int[] weights = new int[n];
+	    int time = 0;
+	    List<int[]> onBridgeC = new ArrayList<>();
+	    
+	    st = new StringTokenizer(br.readLine());
+	    for(int i = 0; i < n; i++) {
+	        weights[i] = Integer.parseInt(st.nextToken());
+	    }
+	    
+	    int onBridgeW = 0; // 다리 위 차들 무게 합
+	    int completeCarIndex = -1; // 다를 건넌 차 인덱스
+	    int nextCarIndex = 0; // 다음 대기 중인 차 인덱스
+	    
+	    while(completeCarIndex < n - 1) {
+	        time++;
+	        //다리 위 차들 한 칸 앞으로
+	        for(int i = 0; i < onBridgeC.size(); i++) {
+	            onBridgeC.get(i)[1]++;    
+	            // 다리를 다 건넘
+	            if(onBridgeC.get(i)[1] > w) {
+	            	onBridgeW -= weights[onBridgeC.get(i)[0]];
+	                onBridgeC.remove(i);
+	                completeCarIndex++;
+	                i--;
+	            }
+	        }
+
+	        // 차 올릴 수 있는 지 검사
+	        if(nextCarIndex < n && onBridgeW + weights[nextCarIndex] <= L && onBridgeC.size() <= w) { //다리에 올릴 수 있는 무게이고 올릴 다리 공간이 있다면
+            	//차 올리기
+                onBridgeC.add(new int[] {nextCarIndex, 1});
+                onBridgeW += weights[nextCarIndex];
+                nextCarIndex++;
+	        }
+	    }
+	    
+	    System.out.print(time);
+	}
+}

--- a/박정훈/9차시/BOJ_13975.java
+++ b/박정훈/9차시/BOJ_13975.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_13975 {
+	
+	public static void main(String[] args) throws IOException{
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    StringBuilder sb = new StringBuilder();
+	    int T = Integer.parseInt(br.readLine());
+	    
+	    for(int tc = 1; tc <= T; tc++) {
+	    	PriorityQueue<Long> pque = new PriorityQueue<>();
+	    	int K = Integer.parseInt(br.readLine());
+	    	long sum = 0;
+	    	StringTokenizer st = new StringTokenizer(br.readLine());
+	    	
+	    	for(int i = 0; i < K; i++) {
+	    		pque.add((long) Integer.parseInt(st.nextToken()));
+	    	}
+	    	
+	    	while(pque.size() > 1) {
+	    		long num1 = pque.poll();
+	    		long num2 = pque.poll();
+	    		
+	    		sum += num1 + num2;
+	    		pque.offer(num1 + num2);
+	    	}
+	    	
+	    	sb.append(sum).append("\n");
+	    }
+	    
+	    System.out.print(sb);
+	}
+}


### PR DESCRIPTION
# 13335번 트럭
## 문제 링크

- 문제 링크 : [13335번 트럭](https://www.acmicpc.net/problem/13335)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(w*n)
<img width="1296" height="84" alt="image" src="https://github.com/user-attachments/assets/2d507459-5b56-4150-9276-9f7a6eee4921" />

<br>

## 접근 방식
다리를 건너는 시뮬레이션을 통해 구현


## 문제 풀이 요약
- List를 통해 현재 다리 위에 있는 차와 해당 차가 다리의 어느 지점을 건너는 지 저장
   - w보다 커지면 다리를 다 건넘
- 차들이 모두 다리를 건널 때까지 한 타임마다 다리 위 차들을 한 칸 앞으로 
   - 다리를 모두 건넌 차는 다리 위 차들의 무게 합 제거 및 리스트에서 제거
- 다리에 차를 올릴 수 있는 지 검사
   - 마지막 차인 지
   - 현재 다리에 올라와 있는 차의 무게 합 + 다음 차 무게가 최대치 이하인 지
   - 다리의 길이가 충분한 지
   - 모두 충족한다면 다리에 차를 올리기 

## 리뷰 요청 포인트
수식으로 계산할 수 있는 방법도 있을까요

## 기타 회고
수식으로 계산하려다가 포기하고 직접 시뮬로 구현했네요
풀고 나서 풀이법을 보니 큐를 이용하면 다리를 건너는 시뮬레이션을 쉽게 구현할 수 있다는 걸 알았습니다


<br>

# 11559번 Puyo Puyo
## 문제 링크

- 문제 링크 : [11559번 Puyo Puyo](https://www.acmicpc.net/problem/11559)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(?)
<img width="1297" height="89" alt="image" src="https://github.com/user-attachments/assets/c2ff5981-740e-4a73-8d83-2eac23ca228c" />

<br>

## 접근 방식
룰에 따라 시뮬레이션 구현


## 문제 풀이 요약
- 한 턴마다 터질 수 있는 뿌요 탐색
   - 뿌요가 있는 칸마다 dfs 탐색 진행
   - 탐색하며 같은 색의 뿌요 발견 시 List에 위치 삽입
   - 모든 탐색 진행 후 List의 크기가 4이상일 시 List에 있는 뿌요 제거
- 모든 뿌요를 탐색 후 터진 뿌요가 있다면 뿌요 내리기
   - 아래서부터 빈칸 탐색
   - 빈 칸 발견 시 위로 뿌요가 있는 지 탐색
      - 첫 뿌요 만날 시 위치 교환
   - 이후 다음 칸부터 모든 칸을 탐색할 때까지 반복
   - chain++
- 터진 뿌요가 없다면
   - 반복 종료  

## 리뷰 요청 포인트
그대로 구현하다보니 코드가 많이 더럽고 가독성도 좋지 않아 보이네요 어떤 알고리즘을 쓰는 문제인가요

## 기타 회고
코드 가독성이 많이 떨어지고 좋은 풀이법이 아닌 것 같아요


<br>

### 🫡 오늘도 고생하셨습니다!



