### PR TITLE
[7차시] 안도형 - 1238번

### DIFF
--- a/안도형/6차시/BOJ_2665.java
+++ b/안도형/6차시/BOJ_2665.java
@@ -47,16 +47,17 @@ public class BOJ_2665 {
                 int nr = p.r + dr[d];
                 int nc = p.c + dc[d];
 
-                if (nr >= 0 && nr < N && nc >= 0 && nc < N) continue;
+                if (nr >= 0 && nr < N && nc >= 0 && nc < N) {
 
-                int cost = dist[p.r][p.c] + (map[nr][nc] == 0 ? 1 : 0);
+                    int cost = dist[p.r][p.c] + (map[nr][nc] == 0 ? 1 : 0);
 
-                if (cost < dist[nr][nc]) {
-                    dist[nr][nc] = cost;
-                    if (map[nr][nc] == 1) {
-                        dq.addFirst(new Pair(nr, nc));
-                    } else {
-                        dq.addLast(new Pair(nr, nc));
+                    if (cost < dist[nr][nc]) {
+                        dist[nr][nc] = cost;
+                        if (map[nr][nc] == 1) {
+                            dq.addFirst(new Pair(nr, nc));
+                        } else {
+                            dq.addLast(new Pair(nr, nc));
+                        }
                     }
                 }
             }

--- a/안도형/7차시/BOJ_1238.java
+++ b/안도형/7차시/BOJ_1238.java
@@ -1,0 +1,75 @@
+package BOJ;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ_1238 {
+    static class Pair{
+        int nextP;
+        int cost;
+
+        public Pair(int nextP, int cost){
+            this.nextP = nextP;
+            this.cost = cost;
+        }
+    }
+
+    static int N, M, X;
+    static ArrayList<ArrayList<Pair>> arr = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int ans = 0;
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        X = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i <= N; i++)
+            arr.add(new ArrayList<>());
+
+        for(int i = 0; i < M; i++){
+            int[] temp = Arrays.stream(br.readLine().split(" "))
+                    .mapToInt(Integer::parseInt).toArray();
+            arr.get(temp[0]).add(new Pair(temp[1], temp[2]));
+        }
+
+        int[] distFromX = bfs(X);
+        for(int i = 1; i <= N; i++){
+            if(i != X)
+                ans = Math.max(bfs(i)[X] + distFromX[i], ans);
+        }
+        System.out.println(ans);
+    }
+
+    public static int[] bfs(int pos){
+        int[] dist = new int[1001];
+
+        for(int i = 1; i <= N; i++)
+            dist[i] = Integer.MAX_VALUE;
+
+        Deque<Integer> dq = new ArrayDeque<>();
+        dq.add(pos);
+        dist[pos] = 0;
+
+        while(!dq.isEmpty()){
+            int currP = dq.poll();
+
+            //if(currP == pos) continue;
+
+            for(Pair p : arr.get(currP)){
+                int cost = dist[currP] + p.cost;
+
+                if (cost < dist[p.nextP]) {
+                    dist[p.nextP] = cost;
+                    dq.add(p.nextP);
+                }
+            }
+        }
+
+        return Arrays.copyOf(dist, N+1);
+    }
+}

--- a/안도형/7차시/BOJ_1238.java
+++ b/안도형/7차시/BOJ_1238.java
@@ -42,6 +42,7 @@ public class BOJ_1238 {
             if(i != X)
                 ans = Math.max(bfs(i)[X] + distFromX[i], ans);
         }
+
         System.out.println(ans);
     }
 


### PR DESCRIPTION

## 문제 링크

- 문제 링크 : [바로가기]https://www.acmicpc.net/problem/1238

## 시간 복잡도 및 공간 복잡도
<html>
<body>
<!--StartFragment-->
메모리 | 시간 | 시간 복잡도 | 공간 복잡도
-- | -- | -- | --
63588KB | 476ms | O(N^2) | O(N)

<!-- notionvc: 1287c026-d3a0-4eac-9bb1-446602cb8d27 --><!--EndFragment-->
</body>
</html>


<br>

## 접근 방식
- X에서 마을로 가는 것은 1번만 돌리면 구해지지만 
- 마을에서 X로 가는 것은 내부 코드 구조 상 각각 구해야 한다고 판단되었다.


## 문제 풀이 요약
- arr에 간선 정보를 저장.
- bfs(X)로 X에서 모든 노드까지의 최단 거리 계산 + X에서 출발하는 최단 거리 배열 distFromX 계산.
- 각 노드에서 X까지의 최단 거리 계산, bfs(i)[X]: 노드 i에서 X까지의 거리
- 왕복 거리 계산 및 최대 값 갱신


## 리뷰 요청 포인트
- 제대로된 다익스트라 알고리즘을 구현하지 못 했습니다. 뭐가 문제가 있을까요.

<br>

### 🫡 오늘도 고생하셨습니다!



