### PR TITLE
[9차시] 남우성- BOJ_13975, BOJ_15903

### DIFF
--- a/남우성/9차시/13975.java
+++ b/남우성/9차시/13975.java
@@ -1,0 +1,34 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		StringBuilder sb = new StringBuilder();
+		
+		int T = Integer.parseInt(br.readLine());
+		for(int testCase = 1; testCase <= T; testCase++) {
+			int n = Integer.parseInt(br.readLine());
+			
+			PriorityQueue<Long> pq = new PriorityQueue<>();
+			st = new StringTokenizer(br.readLine());
+			for(int i = 0; i < n; i++) {
+				pq.add(Long.parseLong(st.nextToken()));
+			}
+			
+			Long result = 0L; Long num = 0L;
+			while(pq.size() > 1) {
+				num = pq.poll() + pq.poll();
+				result += num;
+				pq.add(num);
+			}
+			
+			
+			sb.append(result).append("\n");
+		}
+		System.out.print(sb);
+	}
+}

--- a/남우성/9차시/15903.java
+++ b/남우성/9차시/15903.java
@@ -1,0 +1,30 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		int n = Integer.parseInt(st.nextToken()); int m = Integer.parseInt(st.nextToken());
+		
+		PriorityQueue<Long> pq = new PriorityQueue<>();
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < n; i++) {
+			pq.add(Long.parseLong(st.nextToken()));
+		}
+		
+		for(int i = 0; i < m; i++) {
+			Long sum = pq.poll() + pq.poll();
+			pq.add(sum); pq.add(sum);
+		}
+		
+		Long result = 0L;
+		for(Long num : pq) {
+			result += num;
+		}
+		System.out.println(result);
+	}
+}


### PR DESCRIPTION
# 실버문제

## 문제 링크

- 문제 링크 : [15903 카드합체놀](https://www.acmicpc.net/problem/15903)

## 시간 복잡도 및 공간 복잡도
<img width="1024" height="27" alt="image" src="https://github.com/user-attachments/assets/eb1fdd90-cfe4-49a9-89f7-b19b1e60c17c" />

- 분석한 시간복잡도: O(MlogN)
    - 이유: pq에 정렬할 때 logN이 들어가는데 총 M번 하니까 MlogN

<br>

## 접근 방식
- 처음엔 그리디로 생각하고 풀이 진행
    - pq에 숫자 넣어놓고 2개 poll하고 더하고 2번 add하고 최종 sum이 답일 거라 생각…
    - 근데 아무리 생각해도 맞는데 왜 틀리지 하고 봤는데, int 범위 이슈..


## 문제 풀이 요약
- 문제 분석 및 나의 풀이
    - pq에 숫자를 넣고 2개씩 poll → 더하고 2번 add
- 사용한 알고리즘 및 자료구조
    - pq
    - 이게 가장 최적일 거 같았음


<br><br>


# 골드문제

## 문제 링크

- 문제 링크 : [13975 파일 합치기3](https://www.acmicpc.net/problem/13975)

## 시간 복잡도 및 공간 복잡도
<img width="1029" height="27" alt="image" src="https://github.com/user-attachments/assets/51f0154a-83d7-48dc-814a-45a64bcda366" />


- 분석한 시간복잡도: O(NlogN)
- 이유: pq 정렬에 logN, 이걸 N번 반복

<br>

## 접근 방식
실버 문제와 너무 비슷해서 바로 품…

## 문제 풀이 요약
실버 문제랑 동일


## 리뷰 요청 포인트
이번 문제는 너무 비슷해서 사실상 같은 문제라 쉬어가는 느낌이네요..

사실 얘가 왜 골드 4인지는 모르겠네요… 아마 pq를 안 쓰면 시간 초과가 날 거 같은데,  이것 때문이겠죠..?

일단 문제 풀 때, 입력값 범위 보고 시간복잡도 계산 + 정수 범위 보고 정수형 선택하는 습관은 확실히 들여놔야 겠슴다,, 실버문제에서 int 써서 틀려서ㅠ

<br>

### 🫡 오늘도 고생하셨습니다!



