### PR TITLE
[9차시] 박정훈 - BOJ_13975

### DIFF
--- a/박정훈/9차시/BOJ_13975.java
+++ b/박정훈/9차시/BOJ_13975.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_13975 {
+	
+	public static void main(String[] args) throws IOException{
+	    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	    StringBuilder sb = new StringBuilder();
+	    int T = Integer.parseInt(br.readLine());
+	    
+	    for(int tc = 1; tc <= T; tc++) {
+	    	PriorityQueue<Long> pque = new PriorityQueue<>();
+	    	int K = Integer.parseInt(br.readLine());
+	    	long sum = 0;
+	    	StringTokenizer st = new StringTokenizer(br.readLine());
+	    	
+	    	for(int i = 0; i < K; i++) {
+	    		pque.add((long) Integer.parseInt(st.nextToken()));
+	    	}
+	    	
+	    	while(pque.size() > 1) {
+	    		long num1 = pque.poll();
+	    		long num2 = pque.poll();
+	    		
+	    		sum += num1 + num2;
+	    		pque.offer(num1 + num2);
+	    	}
+	    	
+	    	sb.append(sum).append("\n");
+	    }
+	    
+	    System.out.print(sb);
+	}
+}


### PR DESCRIPTION
# **오늘부터 B형 준비로 인해 골드 문제만 풀겠습니다.**
> B형 문제를 올릴까도 했는데 SWEA에 비밀번호가 걸려있는 문제라서 올려도 되는 지도 모르겠고 하루 한 문제를 매일 풀 수도 없을 것 같아서 나중에 기회되면 올리겠습니다.
---
# 13975번 파일 합치기 3

## 문제 링크

- 문제 링크 : [13975번 파일 합치기 3](https://www.acmicpc.net/problem/13975)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(NlogN)
<img width="1038" height="73" alt="image" src="https://github.com/user-attachments/assets/9978d48a-4b11-4ce6-bb7e-5b1d776f3308" />

<br>

## 접근 방식
- 문제를 보고 입력 개수를 보니 완전 탐색은 불가능하다고 판단
- 더하는 규칙을 찾기 시작했고 가장 작은 수부터 더하면 된다는 걸 찾아냄


## 문제 풀이 요약
- 우선순위 큐를 활용
- 입력을 우선순위 큐에 삽입하여 오름차순 정렬
- 가장 앞에 있는 두 수를 더하여 큐에 삽입
- 더한 값은 sum에 누적


## 리뷰 요청 포인트
X

## 기타 회고
금방 풀고 내서 너무 쉽다고 생각했으나 틀려서 당황했습니다.
하지만 이전에 2805번 나무 자르기 문제에서 sum을 합산하는 과정에서 int형의 범위를 벗어나 틀린 경험이 기억이 나 제한을 보니 int 형의 범위를 넘어가는 걸 발견해서 금방 고쳐서 풀었네요


<br>

### 🫡 오늘도 고생하셨습니다!



