### PR TITLE
[8차시] 이승형 - BOJ_133335, BOJ_11559

### DIFF
--- a/이승형/8차시/BOJ_11559.java
+++ b/이승형/8차시/BOJ_11559.java
@@ -1,0 +1,127 @@
+
+import java.util.*;
+import java.io.*;
+
+
+/*
+ * 1. 입력
+ * 2. dfs로 check
+ * 		체크 성공시 flag true
+ * 3. dfs로 삭제
+ * 		삭제 완료 시 flag false
+ * 4. 중력 실행
+ * 
+ */
+
+public class BOJ_11559 {
+	
+	static int [] dx = {-1,1,0,0};
+	static int [] dy = {0,0, -1, 1};
+	static String [][] board = new String[12][6];
+	static boolean [][] visited;
+	static boolean flag;
+	static int result;
+	static int count;
+	
+	public static void main(String[] args) throws IOException{	
+		inputs();
+		
+		solve();
+
+		System.out.println(result);
+	}
+	
+	static void inputs() throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		for(int i=0;i<12;i++) {
+			board[i] = br.readLine().split("");
+		}
+	}
+	
+	static void solve() {
+		result = 0;
+		while(true) {
+			boolean resultFlag = false;
+			for(int i=11;i>0;i--) {
+				for(int j=0;j<6;j++) {
+					if(board[i][j].equals(".")) continue;
+					
+					count = 1;
+					flag = false;
+					visited = new boolean[12][6];
+					Point now = new Point(i,j,board[i][j]);
+					
+					// 체크 시작
+					dfs(0, now); 
+					// 삭제 시작 + 중력 이동 
+					if(flag) {
+						visited = new boolean[12][6];
+						dfs(1,now);
+						resultFlag = true;
+						flag = false;
+					}
+				}
+			}
+			
+			if(!resultFlag) {
+				break;
+			}
+			
+			doGravitation();
+			result++;
+		}		
+	}
+	
+	// 체크모드 0, 삭제모드 1
+	static void dfs(int mode, Point point) {
+		if(mode==0) {
+			if(count>=4) {
+				flag = true;
+				return;
+			}
+		}else {
+			board[point.x][point.y] = ".";
+		}
+		
+		visited[point.x][point.y] = true;
+		
+		for(int i=0;i<4;i++) {
+			int nx = point.x + dx[i];
+			int ny = point.y + dy[i];
+			
+			if(nx<0 || ny<0 || nx>=12 || ny>=6 
+					|| visited[nx][ny] 
+							|| !board[nx][ny].equals(point.color)) continue;
+			
+			visited[nx][ny] = true;
+			count ++;
+			dfs(mode, new Point(nx,ny, point.color));
+		}
+	}
+	
+	static void doGravitation() {
+		for(int i=0;i<6;i++) {
+			ArrayList<Point> temp = new ArrayList<>();
+			for(int j=11;j>=0;j--) {
+				if(board[j][i].equals(".")) continue;
+				temp.add(new Point(j,i,board[j][i]));
+				board[j][i]=".";
+			}
+			int idx = 11;
+			for(int j=0;j<temp.size();j++) {
+				board[idx--][i]=temp.get(j).color;
+			}
+		}
+	}
+	
+	static class Point {
+		int x,y;
+		String color;
+		
+		public Point(int x, int y, String color) {
+			this.x = x;
+			this.y = y;
+			this.color = color;
+		}
+	}
+}

--- a/이승형/8차시/BOJ_13335.java
+++ b/이승형/8차시/BOJ_13335.java
@@ -1,0 +1,74 @@
+
+import java.util.*;
+import java.io.*;
+
+public class BOJ_13335 {
+	static int N, bridgeLength, bridgeMaximumWeight;
+	static int [] trucks;
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		// Input
+		StringTokenizer str = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(str.nextToken());
+		bridgeLength = Integer.parseInt(str.nextToken());
+		bridgeMaximumWeight = Integer.parseInt(str.nextToken());
+		trucks = new int[N];
+		str = new StringTokenizer(br.readLine());
+		for(int i=0;i<N;i++) {
+			trucks[i] = Integer.parseInt(str.nextToken());
+		}
+		
+		// Solve
+		// 큐, 트럭 인덱스, 현재 총 무게, 시간 
+		Queue<Truck> bridge = new LinkedList<>();
+		int truckIdx = 0;
+		int weightSum = 0;
+		int time = 0;
+		
+		// 첫 트럭 넣기
+		Truck firstTruck = new Truck(bridgeLength, trucks[truckIdx++]);
+		bridge.offer(firstTruck);
+		weightSum += firstTruck.weight;
+		
+		while(!bridge.isEmpty()) {
+			time++;
+			
+			// empty 아닌 경우 peek 시간==0 -> 큐에서 삭제
+			if(bridge.peek().remainingTime==0) {
+				Truck passedTruck = bridge.poll();
+				weightSum -= passedTruck.weight;
+			}
+			
+			// 현재 총 무게 확인, 출발 가능시 추가 
+			while(truckIdx<N && bridgeMaximumWeight >= weightSum+trucks[truckIdx]) {
+				Truck enterTruck = new Truck(bridgeLength, trucks[truckIdx++]);
+				bridge.offer(enterTruck);
+				weightSum += enterTruck.weight;
+				break;
+			}
+			
+			// 전체 큐 내 시간 감소 
+			Iterator<Truck> it = bridge.iterator();
+			while(it.hasNext()) {
+				it.next().decreseTime();
+			}
+		}
+		System.out.println(time);
+	}
+	
+	static class Truck {
+		int remainingTime;
+		int weight;
+		public Truck(int remainingTime, int weight) {
+			this.remainingTime = remainingTime;
+			this.weight = weight;
+		}
+		
+		public void decreseTime() {
+			if(this.remainingTime>0) {
+				this.remainingTime -= 1;
+			}
+		}
+	}
+}


### PR DESCRIPTION
# SILVER

## 문제 링크

- 문제 링크 : https://www.acmicpc.net/problem/13335

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="1282" height="35" alt="스크린샷 2025-08-02 오후 8 06 59" src="https://github.com/user-attachments/assets/084f2872-788c-42c6-9d1e-1e0d42280f4f" />

<br>

## 접근 방식
> 시간의 흐름에 따라 동작의 순서를 생각함
> Queue 사용, 반복하면서 Iterator로 이동 시간 감소


## 문제 풀이 요약
> 1. peek 시간==0 빼기
> 2. 현재 무게 확인, 무게 가능 시 출발
> 3. 다리 위의 차량(큐 내의 원소들) 전체 시간 감소


## 리뷰 요청 포인트
> 더 최적화가 가능할까요?

## 기타 회고
> 일정 흐름에 따라 반복인 경우에는, 반복되는 싸이클 내의 행동의 순서를 먼저 파악하기.

<br>

# GOLD

## 문제 링크

- 문제 링크 : https://www.acmicpc.net/problem/11559

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="882" height="52" alt="스크린샷 2025-08-02 오후 8 13 29" src="https://github.com/user-attachments/assets/95a1dc94-5b7e-41dc-bc4e-2be14e9cf45c" />
시간 복잡도 가늠이 안갑니다..
<br>

## 접근 방식
> ( dfs로 고리찾아서 삭제 -> 중력이동 ) 을 반복하는 방법으로 접근


## 문제 풀이 요약
>  (터트림 -> 중력) 을 반복해서 풀이하려 했으나, 연쇄를 체크하는 시점을 잘못 잡음을 늦게 깨달아서 오래 걸린 문제...
> (터트림 -> 중력)을 해버려서, 터트림이 여러개 있는 경우도 연쇄로 인식되어 버렸음. 
>  입력 자체에 2개 이상의 삭제 가능한 경우가 있는 케이스 계속 실패..
> (터트림*n -> 중력) 이 한 싸이클(연쇄)로 while문을 돌으면서 (탐색-삭제) -> 이후 중력 발생


## 리뷰 요청 포인트
> dfs를 mode를 두가지로 탐색/삭제 하는 방법을 생각했습니다. 다른 방법이 있는 건 코드 리뷰하면서 확인했습니다만, 어떻게 해당 풀이로 접근하게 되셨는지 궁금합니다..!

## 기타 회고
> PR을 쓰면서 문제에 적힌 
> "터질 수 있는 뿌요가 여러 그룹이 있다면 동시에 터져야 하고 여러 그룹이 터지더라도 한번의 연쇄가 추가된다."  
> 를 확인하며,,,문제 잘 읽기

<br>


### 🫡 오늘도 고생하셨습니다!



