### PR TITLE
[11차시] 안도형 - 2110, 2792번

### DIFF
--- a/안도형/11차시/BOJ_2110.java
+++ b/안도형/11차시/BOJ_2110.java
@@ -16,6 +16,7 @@ public class BOJ_2110 {
             arr[i] = Integer.parseInt(br.readLine());
         Arrays.sort(arr);
 
+
         int start = 1;
         int end = arr[N - 1];
         int ans = 0;


### PR DESCRIPTION
## 보석 상자

## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/2792)

## 시간 복잡도 및 공간 복잡도
<img width="700" height="35" alt="image" src="https://github.com/user-attachments/assets/96be8a2f-67c3-4a75-94d4-ca17e53699bf" />

<br>

## 접근 방식
- 각 보석은 한 가지 종류만 가져야 한다. 아래 공유기 문제와 같이
-  바이너리 탐색으로 최소로 차이가 나는 질투심을 구하면 된다고 생각했습니다.


## 문제 풀이 요약
- ``1~보석의 최대 값``에 중간 값을 보석을 나누어줄 최대 나누어줄 양으로 두고 이 양보다 작으면 child에게 줬다고 판단
- 최종 값은 ``ans``에 들어간다.

## 기타 회고
- 공유기 문제를 먼저 풀어 무난하게 풀게되었다.


## 공유기 설치

## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/2110)

## 시간 복잡도 및 공간 복잡도
<img width="712" height="27" alt="image" src="https://github.com/user-attachments/assets/ee06af58-7616-4998-b8f7-cc94a785a680" />

<br>

## 접근 방식
- 공유기 위치가 순서대로 안들어와 정렬해 주었습니다.
- 공유기는 0번 인덱스로 고정했습니다. 최대한 멀어져야 하기 때문에 첫 설치 위치는 불변이라고 생각했습니다.
- 바이너리 탐색으로 최대로 멀어질 값을 구했습니다. 


## 문제 풀이 요약
- 해당 값이 ``mid``값보다 크거나 같다면 공유기 설치 ``count``를 증가 시켜준다.
- 모든 집을 탐색했다면 공유기가 모두 설치되거나 더 많이 되었다면 정답 후보로 두고 ``while``문이 false될때까지 반복한다.
- 최종적으로 ``start``와``end``가 같을 때는 첫번째 ``if``문에 들어와 ans에 정답이 들어가게 됩니다.

## 기타 회고
- 대충 계산 하고 풀게되어 최소 값을 집의 위치가 가장 작은 것으로 두고 풀어 계속 실패가 뜨게되었다.


<br>

### 🫡 오늘도 고생하셨습니다!

