### PR TITLE
[12차시] 남우성 - BOJ_17471, swea_2117

### DIFF
--- a/남우성/12차시/17471.java
+++ b/남우성/12차시/17471.java
@@ -1,0 +1,117 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int result = Integer.MAX_VALUE;
+	static int N;
+	static int[] nodes;
+	static List<List<Integer>> graph;
+	
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		N = Integer.parseInt(br.readLine());
+		nodes = new int[N];
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			nodes[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		Set<Integer> section = new HashSet<>();
+		Set<Integer> remain = new HashSet<>();
+		graph = new ArrayList<>();
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			List<Integer> temp = new ArrayList<>();
+
+			int m = Integer.parseInt(st.nextToken());
+			for(int j = 0; j < m; j++) {
+				temp.add(Integer.parseInt(st.nextToken()) - 1);
+			}
+			
+			graph.add(temp);
+			remain.add(i);
+		}
+		
+		// 완탐으로 풀이, 0번이 기준
+		section.add(0);
+		remain.remove(0);
+		
+		bfs(section, remain, 1);
+		
+		if(result == Integer.MAX_VALUE) result = -1;
+		System.out.println(result);
+	}
+	
+	static public void bfs(Set<Integer> section1, Set<Integer> section2, int index) {
+		if(section1.size() == N) { // 종료조건: 모든 노드를 포함한 경우
+			return;
+		}else {
+			if(checkUnion(section1) && checkUnion(section2)) { // 둘 다 구역이 형성되었다면
+				int sum1 = 0;
+				int sum2 = 0;
+				
+				for(int i = 0; i < N; i++) {
+					if(section1.contains(i)) sum1 += nodes[i];
+					else sum2 += nodes[i];
+				}
+				
+				result = Math.min(result, Math.abs(sum1 - sum2));
+			}
+			
+			if(index < N) {
+				bfs(section1, section2, index+1); //현재 index를 포함하지 않고 호출
+				section1.add(index);
+				section2.remove(index);
+				bfs(section1, section2, index+1); //현재 index를 포함하고 호출
+				section1.remove(index);
+				section2.add(index);
+			}
+		}
+	}
+	
+	static boolean checkUnion(Set<Integer> remain) {
+		boolean[] isVisited = new boolean[N];
+		
+		// 검사 시작 지점 설정
+		int startNode = -1;
+		for(int i = 0; i < N; i++) {
+			if(remain.contains(i)) {
+				startNode = i;
+				break;
+			}
+		}
+		if(startNode == -1) return false;
+		
+		Deque<Integer> queue = new ArrayDeque<>();
+		queue.add(startNode);
+		isVisited[startNode] = true;
+		while(!queue.isEmpty()) {
+			int now = queue.poll();
+			
+			for(int i = 0; i < graph.get(now).size(); i++) {
+				int next = graph.get(now).get(i);
+				if(remain.contains(next) && !isVisited[next]) { // 검사 구역이고, 방문하지 않은 경우만 추가
+					queue.add(next);
+					isVisited[next] = true;
+				}
+			}
+		}
+		
+		//모든 remain 중에 하나라도 못 갔으면 false
+		for(int i = 0; i < N; i++) {
+			if(remain.contains(i) && !isVisited[i]) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/남우성/12차시/swea_2117.java
+++ b/남우성/12차시/swea_2117.java
@@ -1,0 +1,65 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Solution {
+	
+	static int[][] board;
+	static int N;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer st;
+		
+		int T = Integer.parseInt(br.readLine());
+		for(int testCase = 1; testCase <= T; testCase++) {
+			st = new StringTokenizer(br.readLine());
+			N = Integer.parseInt(st.nextToken()); int M = Integer.parseInt(st.nextToken());
+			
+			board = new int[N][N];
+			int maxHome = 0;
+			for(int i = 0; i < N; i++) {
+				st = new StringTokenizer(br.readLine());
+				for(int j = 0; j < N; j++) {
+					board[i][j] = Integer.parseInt(st.nextToken());
+					if(board[i][j] == 1) maxHome++;
+				}
+			}
+			
+			int maxIncome = maxHome * M;
+			int result = 0;
+			int size = 0;
+			while(true) {
+				size++;
+				int nowCost = size * size + (size - 1) * (size - 1);
+				if(nowCost > maxIncome) break; // 현재 비용이 최대 수익보다 커지면 종료
+				
+				for(int i = 0; i < N; i++) {
+					for(int j = 0; j < N; j++) {
+						int nowHome = checkHome(i, j, size);
+						if(nowHome * M >= nowCost) result = Math.max(result, nowHome); // 비용감당이 되는 경우만 result update
+					}
+				}
+				
+			}
+			sb.append("#").append(testCase).append(" ").append(result).append("\n");
+		}
+		System.out.print(sb);
+	}
+	
+	static int checkHome(int x, int y, int size) {
+		int stand = 0; // y좌표 설정을 위한 변수
+		int cnt = 0;
+		for(int i = x - size + 1; i <= x + size - 1; i++) {
+			stand++;
+			int dy = Math.abs(stand - size); //size -1 -> size -2 -> ... -> 0 -> ... -> size - 2 -> size - 1
+			for(int j = y - size + 1 + dy; j <= y + size - 1 - dy; j++) {
+				if(i >= 0 && i < N && j >= 0 && j < N) {
+					if(board[i][j] == 1) cnt++;
+				}
+			}
+		}
+		return cnt;
+	}
+}


### PR DESCRIPTION
# 백준문제

## 문제 링크

- 문제 링크 : [17471 게리멘더링](https://www.acmicpc.net/problem/17471)

## 시간 복잡도 및 공간 복잡도
<img width="1034" height="27" alt="image" src="https://github.com/user-attachments/assets/2295e69b-5cd7-4147-a1eb-5cc4203080db" />

- 분석한 시간복잡도: O(2^9 * N2)
- 이유: index마다 2개의 case가 중첩되어 생기고, 각 case에서 bfs 탐색을 진행

<br>

<접근 방식(문제 풀이까지 고민한 내용들)>
- 완탐으로 풀이해야 된다고 생각함
- 와중에 최적화를 생각하려고 했는데  오히려 무한루프나 스택오버플로우 같은 것들 발생해서 다시 기본 풀이로 회귀…

<문제 풀이 요약>

- 문제 분석 및 나의 풀이
    - 일단 0번인덱스는 무주건 포함
    - 이후 1번부터 포함, 미포함 경우를 모두 조사
    - 나머지 구역에 대해서는 bfs를 돌리면서 전부 연결되었는지 검증
- 사용한 알고리즘 및 자료구조
    - 이유: 완탐 + bfs


<br><br>


# swea문제

## 문제 링크

- 문제 링크 : [2117 [모의 SW 역량테스트] 홈 방범 서비스](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV5V61LqAf8DFAWu)

## 시간 복잡도 및 공간 복잡도
<img width="1166" height="78" alt="image" src="https://github.com/user-attachments/assets/dd96744f-8711-4bf2-a1e8-efd98de9b8fd" />

- 분석한 시간복잡도: O(N^5)..?
- 이유: 일단 size만큼 반복 n > 2차원 배열 조사 N^2 > 한 인덱스마다 마름모 모양 조사 N^2 => 총 N^5..?

<br>

## 접근 방식
- 이거 처음에 이분탐색으로 풀이 도전함
    - 집이 10개라면 5개인 경우 검사 -> 7 or 3개 검사 -> ... => 최대 집 개수 검사
    - 이렇게 하면 size를 반복 n을 logN으로 줄일 수 있을 것 같았음
    - 근데 구현까지 다 하고 보니까 이분 탐색 쓰면 안됐음...
    - 예를 들어 집이 5개인 경우는 정답이 아닌데, 집이 10개인 경우에는 커버할 수 있는 경우가 있어서 적용하면 안 됐음...
=> 그냥 완탐으로 회귀..

## 문제 풀이 요약
- 먼저 최대 집 개수 * 이득을 기준으로 최대로 설치 가능한 size를 설정
- size를 1부터 최대 까지 모든 case를 검사
- 검사하면서 비용이 감당 가능할 때 마다 result를 갱신해나감


## 리뷰 요청 포인트
- 음 일단 생각하면할수록 이 문제는 완탐이 답인 거 같은데, 최적화 방법은 없겠죠..?


<br>

### 🫡 오늘도 고생하셨습니다!



