### PR TITLE
[12차시] 박정훈 - BOJ_17471, SWEA_2117

### DIFF
--- a/박정훈/12차시/BOJ_17471.java
+++ b/박정훈/12차시/BOJ_17471.java
@@ -1,0 +1,111 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class BOJ_17471 {
+    static int N, sum;
+    static int[] population;
+    static int[] union;
+    static List<Integer>[] graph;
+    static int min = Integer.MAX_VALUE;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        sum = 0;
+        
+        population = new int[N + 1];
+        graph = new ArrayList[N + 1];
+        union = new int[N + 1];
+        
+        //인구수 입력, 그래프 초기화
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+        	int p = Integer.parseInt(st.nextToken());
+            population[i] = p;
+            sum += p; //총 인구수
+            graph[i] = new ArrayList<>();
+        }
+        
+        // 그래프 입력
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int M = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < M; j++) {
+                int neighbor = Integer.parseInt(st.nextToken());
+                graph[i].add(neighbor);
+            }
+        }
+        
+        // 1번 지역 1번 집합
+        union[1] = 1;
+        dfs(1);
+        
+        // 1번 지역 2번 집합
+        union[1] = 2;
+        dfs(1);
+
+        //max_value면 두 집합으로 나뉘는 경우가 없음
+        System.out.print(min == Integer.MAX_VALUE? -1 : min);
+    }
+    
+    public static void dfs(int node) {
+    	if(node == N) { // 모든 지역 할당 완료
+    		boolean[] visited = new boolean[N+1];
+    		
+    		// 집합 개수 세기
+    		int unionCount = 0;
+    		for(int i = 1; i <= N; i++) {
+    			if(!visited[i]) {
+    				unionCount++; // 집합이 몇 개로 나뉘는 지 카운트
+    				// 같은 집합은 모두 방문 처리
+    				bfs(i, union, visited);
+    			}
+    		}
+    		
+    		// 집합이 2개면
+    		if(unionCount == 2) {
+    			int uSum = 0;
+    			for(int i = 1; i <= N; i++) {
+    				if(union[i] == 1) { // 1번 집합
+    					uSum += population[i];
+    				}
+    			}
+    			min = Math.min(min, Math.abs(uSum - (sum - uSum)));
+    		}
+    		return;
+    	}
+    	
+    	// 다음 지역 1번 집합으로 할당
+    	union[node + 1] = 1;
+    	dfs(node + 1);
+    	
+    	// 다음 지역 2번 집합으로 할당
+    	union[node + 1] = 2;
+    	dfs(node + 1);
+    }
+    
+    public static void bfs(int node, int[] union, boolean[] visited) {
+    	Deque<Integer> deque = new ArrayDeque<>();
+    	deque.offer(node);
+    	visited[node] = true;
+    	
+    	while(!deque.isEmpty()) {
+    		int n = deque.poll();
+    		
+    		for(int i = 0; i < graph[n].size(); i++) {
+    			int next = graph[n].get(i);
+    			// 같은 집합이고 방문하지 않았다면
+    			if(union[next] == union[node] && !visited[next]) {
+    				deque.offer(next);
+    				visited[next] = true;
+    			}
+    		}
+    	}
+    }
+}

--- a/박정훈/12차시/SWEA_2117.java
+++ b/박정훈/12차시/SWEA_2117.java
@@ -1,0 +1,90 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+public class SWEA_2117 {
+	static int[] dx = {0, 1, 0, -1};
+	static int[] dy = {-1, 0, 1, 0};
+	static int N;
+
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int T = Integer.parseInt(br.readLine());
+		
+		for(int tc = 1; tc <= T; tc++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());	
+			N = Integer.parseInt(st.nextToken());
+			int M = Integer.parseInt(st.nextToken());
+			int[][] city = new int[N][N];
+			int maxHouse = 0;
+			int total = 0;
+			//입력
+			for(int y = 0; y < N; y++) {
+				st = new StringTokenizer(br.readLine());
+				for(int x = 0; x < N; x++) {
+					int n = Integer.parseInt(st.nextToken());
+					city[y][x] = n;
+					total++; //집 총 개수
+				}
+			}
+			//얻을 수 있는 최대 수익
+			int maxCost = total * M;
+			
+			//모든 구역을 시작점으로 탐색
+			for(int y = 0; y < N; y++) {
+				for(int x = 0; x < N; x++) {
+					int k = 1;
+					int cost = (k * k) + ((k - 1) * (k - 1));
+					while(maxCost - cost >= 0) {
+						int house = bfs(city, x, y, k);
+						if((house * M) - cost >= 0) { 
+							maxHouse = Math.max(maxHouse, house);
+						}
+						k++;
+						cost = (k * k) + ((k - 1) * (k - 1)); //비용 계산
+					}
+				}
+			}
+			sb.append("#").append(tc).append(" ").append(maxHouse).append("\n");
+		}
+		System.out.print(sb);
+	}
+	
+	public static int bfs(int[][] city, int x, int y, int maxK) {
+		Deque<int[]> deque = new ArrayDeque<>();
+		boolean[][] visited = new boolean[N][N];
+		deque.offer(new int[] {x, y, 1}); // 2번 인덱스는 maxK까지만 감
+		visited[y][x] = true;
+		int house = 0;
+		
+		while(!deque.isEmpty()) {
+			int[] info = deque.poll();
+			int cx = info[0];
+			int cy = info[1];
+			int ck = info[2];
+			// 집 개수 세기
+			if(city[cy][cx] == 1) {
+				house++;
+			}
+			//4방향
+			for(int i = 0; i < 4; i++) {
+				int nx = cx + dx[i];
+				int ny = cy + dy[i];
+				
+				//범위 밖
+				if(nx < 0 || nx >= N || ny < 0 || ny >= N) continue;
+				
+				if(!visited[ny][nx] && ck < maxK) {
+					visited[ny][nx] = true;
+					deque.offer(new int[] {nx, ny, ck + 1});
+				}
+			}
+		}
+		return house;
+	}
+
+}


### PR DESCRIPTION
# 17471번 게리맨더링
## 문제 링크

- 문제 링크 : [17471번 게리맨더링](https://www.acmicpc.net/problem/17471)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(2^N * N)
<img width="854" height="68" alt="image" src="https://github.com/user-attachments/assets/b0995dec-7092-430f-b452-9d361d197375" />


<br>

## 접근 방식
> 노드마다 집합을 2개로 임의로 설정 후, 같은 집합끼리 연결되어 있는 지 확인


## 문제 풀이 요약
- 각 노드마다 1번 집합과 2번 집합으로 임의로 할당
- 모든 노드를 할당 완료했다면
   - 각각의 집합이 연결되어 있는 지 확인
   - 두 집합 모두 연결되어 있어 2개로 나뉘어졌다면 인구수 차이의 최소값 갱신


## 리뷰 요청 포인트
제가 원래 풀던 풀이에서 dfs 방식으로 했는데, 1-2, 1-3-4, 이렇게 연결되어 있을 때 1,2,3 이렇게가 하나의 집합으로 할 수 있는 방법이 있을까요. 생각이 안 나서 그 풀이는 포기했습니다.

## 기타 회고
한 노드를 시작점으로 시작해서 연결된 노드를 하나 씩 임의의 집합으로 할당하고 2개의 영역으로 나뉘는 지 확인하는 방법으로 풀다가 반례를 해결하지 못 해서 포기하고 정답 코드 본 후에 힌트를 얻어 풀었습니다. 어렵네요...


<br>

### 🫡 오늘도 고생하셨습니다!

# SWEA 2117번 홈 방범 서비스
## 문제 링크

- 문제 링크 : [2117번 홈 방범 서비스](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV5V61LqAf8DFAWu)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(N^2 * M * K)
<img width="871" height="87" alt="image" src="https://github.com/user-attachments/assets/4135e697-4bd1-462a-8e0d-0dac2c3c2b39" />


<br>

## 접근 방식
> 모든 구역을 시작점으로 완전탐색


## 문제 풀이 요약
- 각 구역마다 시작점으로 영역을 확장하며 탐색
- 얻을 수 있는 최대 수익 - 구역 확장 시 드는 비용이 0보다 클 때까지만 반복
- 현재 크기의 구역을 서비스할 시 얻는 수익이 0보다 클 때에만 서비스 받는 집의 개수 갱신


## 리뷰 요청 포인트
풀고나서 다른 분들 보니까 제가 비효율적으로 풀었네요. 효율적인 방법이 뭔가요

## 기타 회고
다들 이런 방법으로 풀었을 거라고 생각했는데 저만 실행시간이나 메모리 측면에서 많이 비효율적이네요


<br>

### 🫡 오늘도 고생하셨습니다!



