### PR TITLE
[14차시] 박정훈 - SWEA_1249, SWEA_2105

### DIFF
--- a/박정훈/14차시/SWEA_1249.java
+++ b/박정훈/14차시/SWEA_1249.java
@@ -1,0 +1,64 @@
+import java.util.*;
+import java.io.*;
+
+class SWEA_1249
+{
+	public static void main(String args[]) throws Exception
+	{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+
+		for(int test_case = 1; test_case <= T; test_case++)
+		{
+			/////////////////////////////////////////////////////////////////////////////////////////////
+			StringBuilder sb = new StringBuilder();
+			int N = Integer.parseInt(br.readLine());
+            int[][] map = new int[N][N];
+            int[][] minValue = new int[N][N]; // 각 칸에 도착하는 최소 시간
+            int[] dx = new int[] { 1, -1, 0, 0 }; // 이동 방향
+            int[] dy = new int[] { 0, 0, 1, -1 }; // 이동 방향
+            Queue<int[]> que = new LinkedList<>();
+            que.add(new int[] {0, 0, 0}); // 시작점
+            
+            for(int i = 0; i < N; i++) {
+                sb = new StringBuilder(br.readLine());
+            	for(int j = 0; j < N; j++) {
+                    map[i][j] = Integer.parseInt(String.valueOf(sb.charAt(j))); 
+                    minValue[i][j] = Integer.MAX_VALUE;
+                }
+            }
+            
+            while(!que.isEmpty()) {
+            	int[] info = new int[3];
+            	info = que.poll();
+            	
+            	// 4방향 이동
+            	for(int i = 0; i < 4; i++) {
+            		int x = info[0];
+            		int y = info[1];
+            		int time = info[2];
+            		
+            		x += dx[i];
+            		y += dy[i];
+            		if(x < 0 || x >= N || y < 0 || y >= N) { // 범위를 벗어남
+            			continue;
+            		}
+            		
+            		if(x == N-1 && y == N-1) { // 목적지 도착
+            			minValue[y][x] = Math.min(minValue[y][x], time);
+            		} else {
+	            		time += map[y][x]; // 이동한 칸의 복구 시간 더하기
+	            		if(time < minValue[y][x]) { // 현재 경로가 다른 경로보다 적은 시간이라면
+	            			minValue[y][x]= time; // 최소 시간 갱신
+	            			que.add(new int[] {x, y, time}); // 큐에 추가
+	            		}
+            		}
+            	}
+            }
+            
+            // 최소 시간 출력
+            System.out.println("#" + test_case + " " + minValue[N-1][N-1]);  
+			/////////////////////////////////////////////////////////////////////////////////////////////
+		}
+	}
+}

--- a/박정훈/14차시/SWEA_2105.java
+++ b/박정훈/14차시/SWEA_2105.java
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+class SWEA_2105 {
+	static int[] dx = {1, -1, -1, 1};
+	static int[] dy = {1, 1, -1, -1};
+	static int max, N;
+	static int[][] table;
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		int T = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		for(int tc = 1; tc <= T; tc++) {
+			N = Integer.parseInt(br.readLine());
+			max = -1;
+			table = new int[N][N];
+			
+			//입력
+			for(int i = 0; i < N; i++) {
+				st = new StringTokenizer(br.readLine());
+				for(int j = 0; j < N; j++) {
+					table[i][j] = Integer.parseInt(st.nextToken());
+				}
+			}
+			
+			List<Integer> list = new ArrayList<>();
+			for(int y = 0; y < N - 2; y++) {
+				for(int x = 1; x < N - 1; x++) { // 0번 인덱스는 돌아오지 못 함 N-1번 인덱스는 출발 못 함 
+					list.add(table[y][x]);
+					dfs(x, y, x + dx[0], y + dy[0], 1, list, 0);
+					list.remove(list.size() - 1);
+				}
+			}
+			
+			sb.append("#").append(tc).append(" ").append(max).append("\n");
+		}
+		
+		System.out.print(sb);
+	}
+	
+	public static void dfs(int startX, int startY, int x, int y, int count, List<Integer> list, int direct) {
+		//시작점으로 돌아옴 (그대로 되돌아 오는 것 방지를 위해 4개이상 체크)
+		if(x == startX && y == startY && count >= 4) {
+			max = Math.max(max, count);
+			return;
+		}
+		if(list.contains(table[y][x])) { //현재 디저트 먹음
+			return;
+		}
+		
+		//왼쪽 위로 올라가다가 시작지점과 같은 대각선이면 시작지점 방향으로 가야함
+		if(direct == 2 && x + y == startX + startY) {
+			list.add(table[y][x]);
+			dfs(startX, startY, x + dx[3], y + dy[3], count + 1, list, 3);
+			list.remove(list.size() - 1);
+			return;
+		}
+		
+		// 대각선으로 갈 수있는 만큼 가면서 사각형 그리는 방향으로
+		for(int d = direct; d < 4; d++) {
+			int nx = x + dx[d];
+			int ny = y + dy[d];
+			
+			//범위 체크
+			if(nx < 0 || nx >= N || ny < 0 || ny >= N) continue;
+			
+			list.add(table[y][x]);
+			dfs(startX, startY, nx, ny, count + 1, list, d);
+			list.remove(list.size() - 1);
+		}
+	}
+}


### PR DESCRIPTION
# SWEA 1249번 보급로

## 문제 링크

- 문제 링크 : [SWEA 1249번 보급로](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV15QRX6APsCFAYD)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(N^4)
<img width="1175" height="85" alt="image" src="https://github.com/user-attachments/assets/593727e4-7fb4-49b4-9c83-7bb9d8447ecf" />

<br>

## 접근 방식
bfs 방식으로 최소 시간 갱신


## 문제 풀이 요약
bfs 탐색을 통해 각 노드에 도착하는 최소 시간 갱신


## 리뷰 요청 포인트

## 기타 회고
문제 진도를 따라잡기 위해서 4개월 전에 풀었던 문제인데 다시 풀지 않고 제 코드를 리뷰하는 방식으로 하겠습니다.
지금 풀이를 보니 많이 잘못 구현을 했네요.
다익스트라 알고리즘에 우선순위 큐를 사용하지 않았고 방문 처리도 하지 않아 중복 탐색을 하고 있습니다.
이 문제를 풀 때, 다익스트라 알고리즘을 모르는 상태로 풀이를 했던 것 같습니다.
지금 푼다면 다익스트라로 풀 것 같습니다.


<br>

### 🫡 오늘도 고생하셨습니다!

# SWEA 2105번 디저트 카페

## 문제 링크

- 문제 링크 : [SWEA 2105번 디저트 카페](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV5VwAr6APYDFAWu&)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(N^2 * 4^N)
<img width="1169" height="91" alt="image" src="https://github.com/user-attachments/assets/4a3922ab-c2ce-4039-be06-b15a6aa63824" />

<br>

## 접근 방식
dfs 탐색

## 문제 풀이 요약
- 각 시작점마다 우하단으로 시작해, 좌하단, 좌상단, 우상단의 방향으로 돌아 사각형을 만들기
   - 사각형을 만들지 못 하는 지점은 탐색X
- 현재 방향으로 갈 수 있는만큼 가면서 디저트 리스트 추가
   - 만약 현재 탐색이 불가능한 탐색일 경우 리스트 삭제(백트래킹)
   - 다음 진로가 불가능한 탐색인 경우 다음 방향으로 탐색
- 좌상단으로의 탐색의 경우 탐색 진행하다가 우상단으로 올라가야 시작점을 만날 수 있다면 방향 바꿔 탐색
   - 시작점의 (x, y)값과 현재 탐색 좌표 (x, y)값의 합이 같다면 올라가야 함
- 시작점으로 돌아왔다면 max 값 갱신
   - 사각형이 만들어지는 탐색 최소가 4
   - 우하단으로 갔다가 좌상단으로 돌아오는 경우를 방지하기 위해 `count >= 4` 이상일 경우에만 갱신
   -  4이상으로 되돌아오는 경우는 먹었던 디저트인 지 검사하는 분기점에서 제거됨

## 리뷰 요청 포인트

## 기타 회고
사각형을 만드는 로직이 금방 생각이나서 쉽게 풀 수 있었습니다.

<br>

### 🫡 오늘도 고생하셨습니다!

