### PR TITLE
[15, 16 차시] 천보성 - 활주로 건설, 키 순서, 무선 충전

### DIFF
--- a/천보성/15차시/SWEA_4014.java
+++ b/천보성/15차시/SWEA_4014.java
@@ -1,0 +1,94 @@
+import java.io.*;
+import java.util.*;
+
+public class SWEA_4014 {
+
+    static int N, X;
+    static int[][] map;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine().trim());
+
+        for (int test_case=1;test_case<=T;test_case++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            X = Integer.parseInt(st.nextToken());
+
+            map = new int[N][N];
+            for (int i=0;i<N;i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j=0;j<N;j++) {
+                    map[i][j] = Integer.parseInt(st.nextToken());
+                }
+            }
+
+            int answer = 0;
+
+            for (int i=0;i<N;i++) {
+                int[] line = new int[N];
+                System.arraycopy(map[i], 0, line, 0, N);
+                if (canBuild(line)){
+                    answer++;
+                }
+            }
+
+            for (int j=0;j<N;j++) {
+                int[] line = new int[N];
+                for (int i=0;i<N;i++){
+                    line[i] = map[i][j];
+                }
+                if (canBuild(line)){
+                    answer++;
+                }
+            }
+
+            sb.append('#').append(test_case).append(' ');
+            sb.append(answer).append('\n');
+        }
+
+        System.out.print(sb);
+    }
+
+    static boolean canBuild(int[] line) {
+        boolean[] used = new boolean[N];
+
+        for (int i=0;i<N-1;i++) {
+            int diff = line[i+1] - line[i];
+            
+            if (diff == 0) continue;
+            if (diff >= 2 || diff <= -2) return false;
+            if (diff == 1) {
+                int h = line[i];
+
+                for (int k=0;k<X;k++) {
+                    int idx = i - k;
+                    if (idx < 0 || idx >= N) return false;
+                    if (line[idx] != h || used[idx]) return false;
+                }
+                
+                for (int k=0;k<X;k++) {
+                    used[i-k] = true;
+                }
+            }
+
+            else if (diff == -1) {
+                int h = line[i + 1];
+
+                for (int k=1;k<=X;k++) {
+                    int idx = i + k;
+                    if (idx < 0 || idx >= N) return false;
+                    if (line[idx] != h || used[idx]) return false;
+                }
+                
+                for (int k=1;k<=X;k++) {
+                    used[i+k] = true;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/천보성/16차시/SWEA_5643.java
+++ b/천보성/16차시/SWEA_5643.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class SWEA_5643 {
+	static ArrayList<ArrayList<Integer>> graph;
+	static int N;
+	static ArrayList<ArrayList<Integer>> bigList;
+	static ArrayList<ArrayList<Integer>> smallList;
+	
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int T = Integer.parseInt(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		for(int testcase=1;testcase<=T;testcase++) {
+			N = Integer.parseInt(br.readLine());
+			int M = Integer.parseInt(br.readLine());
+			
+			graph  = new ArrayList<>();
+			bigList = new ArrayList<>();
+			smallList = new ArrayList<>();
+			
+			for(int i=0;i<=N;i++) {
+				graph.add(new ArrayList<>());
+				bigList.add(new ArrayList<>());
+				smallList.add(new ArrayList<>());
+			}
+			
+			for(int i=0;i<M;i++) {
+				StringTokenizer st = new StringTokenizer(br.readLine());
+				int a = Integer.parseInt(st.nextToken());
+				int b = Integer.parseInt(st.nextToken());
+				
+				graph.get(a).add(b);
+			}
+			
+			for(int i=1;i<=N;i++) {
+				bfs(i);
+			}
+			int cnt = 0;
+			for(int i=1;i<=N;i++) {
+				if(N-1 == bigList.get(i).size() + smallList.get(i).size()) {
+					cnt++;
+				}
+			}
+			sb.append('#').append(testcase).append(' ');
+			sb.append(cnt);
+			sb.append('\n');
+			
+		}
+		System.out.println(sb);
+	}
+	
+	public static void bfs(int start) {
+		Queue<Integer> queue = new LinkedList<>();
+		queue.add(start);
+		boolean[] visited = new boolean[N+1];
+		visited[start] = true;
+		
+		while(!queue.isEmpty()) {
+			int now = queue.poll();
+			
+			for(int next : graph.get(now)) {
+				if(visited[next]) continue;
+				visited[next] = true;
+				bigList.get(start).add(next);
+				smallList.get(next).add(start);
+				queue.add(next);
+			}
+		}
+
+	}
+}

--- a/천보성/16차시/SWEA_5644.java
+++ b/천보성/16차시/SWEA_5644.java
@@ -1,0 +1,129 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class SWEA_5644 {
+
+    static class Battery{
+        int x;
+        int y;
+        int c;
+        int p;
+        Battery(int x, int y, int c, int p){
+            this.x = x;
+            this.y = y;
+            this.c = c;
+            this.p = p;
+        }
+    }
+    static int[] dx = {0,0,1,0,-1};
+    static int[] dy = {0,-1,0,1,0};
+    static ArrayList<Battery> batteryList;
+    static int M;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        for (int testcase=1;testcase<=T;testcase++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            M = Integer.parseInt(st.nextToken());
+            int A = Integer.parseInt(st.nextToken());
+
+            batteryList = new ArrayList<>();
+            int[] peopleA = new int[M+1];
+            int[] peopleB = new int[M+1];
+            st = new StringTokenizer(br.readLine());
+            for (int i=1;i<=M;i++){
+                peopleA[i] = Integer.parseInt(st.nextToken());
+            }
+
+            st = new StringTokenizer(br.readLine());
+            for (int i=1;i<=M;i++){
+                peopleB[i] = Integer.parseInt(st.nextToken());
+            }
+
+            for (int i=0;i<A;i++){
+                st = new StringTokenizer(br.readLine());
+                int x = Integer.parseInt(st.nextToken());
+                int y = Integer.parseInt(st.nextToken());
+                int C = Integer.parseInt(st.nextToken());
+                int P = Integer.parseInt(st.nextToken());
+                batteryList.add(new Battery(x, y, C, P));
+            }
+
+            sb.append('#').append(testcase).append(' ');
+            sb.append(simul(peopleA, peopleB));
+            sb.append('\n');
+        }
+        System.out.println(sb);
+    }
+
+    public static int simul(int[] peopleA, int[] peopleB){
+        int aX = 1;
+        int aY = 1;
+        int bX = 10;
+        int bY = 10;
+        int total = 0;
+
+        for (int t=0;t<=M;t++){
+
+            ArrayList<Integer> listA = getCanChargeList(aX, aY);
+            ArrayList<Integer> listB = getCanChargeList(bX, bY);
+
+            int max = 0;
+
+            if (listA.isEmpty()){
+                for (int idx : listB){
+                    max = Math.max(max, batteryList.get(idx).p);
+                }
+            }
+            else if (listB.isEmpty()){
+                for (int idx : listA){
+                    max = Math.max(max, batteryList.get(idx).p);
+                }
+            }
+
+            else{
+                for (int idxA : listA){
+                    for (int idxB : listB){
+                        if (idxA == idxB){
+                            max = Math.max(max,batteryList.get(idxA).p);
+                        }
+                        else{
+                            max = Math.max(max, batteryList.get(idxA).p + batteryList.get(idxB).p);
+                        }
+                    }
+                }
+            }
+
+            total += max;
+
+            if (t == M) break;
+
+            int dir1 = peopleA[t+1];
+            int dir2 = peopleB[t+1];
+
+            aX += dx[dir1];
+            aY += dy[dir1];
+            bX += dx[dir2];
+            bY += dy[dir2];
+        }
+        return total;
+    }
+    public static ArrayList<Integer> getCanChargeList(int x, int y){
+        ArrayList<Integer> list = new ArrayList<>();
+        for (int i=0;i<batteryList.size();i++){
+            Battery b = batteryList.get(i);
+
+            if (Math.abs(b.x - x) + Math.abs(b.y - y) <= b.c){
+                list.add(i);
+            }
+        }
+        return list;
+    }
+}


### PR DESCRIPTION
# SWEA_4014 활주로 건설

## 문제 링크

- 문제 링크 : [바로가기](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AWIeW7FakkUDFAVH)

## 시간 복잡도 및 공간 복잡도
<img width="565" height="73" alt="image" src="https://github.com/user-attachments/assets/7b968ed4-d9e0-4ebe-9789-18c7e920f996" />
<br>

## 접근 방식
 단순한 구현 문제로 문제 해석이 가장 중요했던 것 같습니다.
처음엔 문제를 잘못 읽어서 한 줄에 여러 개의 활주로를 건설하면 다 카운트 되는 줄 알았고
 가로 세로 겹치게 못하는 줄 알았는데 그게 아니었네요.
그냥 조건 따라서 구현하면 되는 문제인 것 같습니다.

## 문제 풀이 요약
- 가로, 세로 나누어서 탐색
- 앞 블럭과 뒷 블럭의 차이를 구하고 차이가 2 이상이면 그 줄에는 활주로 x
- 차이가 1인 곳을 찾으면 그 인덱스를 기준으로 탐색, k이상이면 설치 성공

## 리뷰 요청 포인트


## 기타 회고

<br>

# SWEA_5643 키 순서

## 문제 링크

- 문제 링크 : [바로가기](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AWXQsLWKd5cDFAUo)

## 시간 복잡도 및 공간 복잡도
<img width="493" height="80" alt="image" src="https://github.com/user-attachments/assets/fb56be2b-badb-416a-ab46-669b9253b384" />
<br>

## 접근 방식
생각만 한다면 구현 자체는 엄청 쉬웠던 것 같습니다.
예제에 나온 다른 노드들과 4번 노드의 차이를 보니 4번 노드보다 큰 사람들과 작은 사람들의 합이 본인을 제외한 N-1 이었습니다.
bfs를 활용하여 1번 노드부터 탐색을 진행하며 bigList와 smallList에 저장을 하고 그 합이 N-1인 개수를 센다면 답일 거라 생각했습니다.

## 문제 풀이 요약
- smallList, bigList 를 활용
- 1번 노드부터 bfs를 진행하며 노드들을 저장, 순서대로 진행하다보니 탐색이 가능하면 무조건 본인보다 큼
- bigList와 smallList의 같은 인덱스의 사이즈를 합해서 N-1인지 확인

## 리뷰 요청 포인트


## 기타 회고

<br>

# SWEA_5644 무선 충전

## 문제 링크

- 문제 링크 : [바로가기](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AWXRDL1aeugDFAUo)

## 시간 복잡도 및 공간 복잡도
<img width="486" height="81" alt="image" src="https://github.com/user-attachments/assets/12b605e2-f5fd-4a88-97df-bd5abbd7a86f" />

<br>

## 접근 방식
배터리 개수가 엄청 적길래 브루트 포스로 진행 가능
A,B 가 진행할 때 좌표마다 충전할 수 있는 최댓값을 뽑으면 된다고 생각했습니다.

## 문제 풀이 요약
- 좌표마다 충전이 가능한 배터리들을 리스트로 가져옴
- 거기서 A가 충전 가능할 때, B가 충전 가능할 때, 둘 다 충전 가능할 때를 나눔 
- max 값을 계산해서 다음 시간대로 진행

## 리뷰 요청 포인트


## 기타 회고
<br>
### 🫡 오늘도 고생하셨습니다!



