### PR TITLE
[12차시] 이승형 - BOJ_17471

### DIFF
--- a/이승형/12차시/BOJ_17471.java
+++ b/이승형/12차시/BOJ_17471.java
@@ -1,0 +1,126 @@
+
+import java.util.*;
+import java.io.*;
+
+/*
+ * 백트래킹
+ * 	그룹 구성
+ * 		Set에 선거구 저장하여 넘김
+ * 연결 확인 
+ * 	bfs
+ * 	계산
+ */
+public class BOJ_17471 {
+	static int N, result, p;
+	static int [] population;
+	static ArrayList<ArrayList<Integer>> graph;
+	public static void main(String [] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer str;
+		
+		N = Integer.parseInt(br.readLine());
+		population = new int[N+1];
+		graph = new ArrayList<>();
+		for(int i=0;i<=N;i++) {
+			graph.add(new ArrayList<>());
+		}
+		
+		str = new StringTokenizer(br.readLine());
+		for(int i=1;i<=N;i++) {	
+			population[i] = Integer.parseInt(str.nextToken());
+		}
+		
+		for(int i=1;i<=N;i++) {
+			str = new StringTokenizer(br.readLine());
+			int M = Integer.parseInt(str.nextToken());
+			for(int j=0;j<M;j++) {
+				int end = Integer.parseInt(str.nextToken());
+				graph.get(i).add(end);
+				graph.get(end).add(i);
+			}
+		}
+	
+		//////////////////////////////////////// 입력 끝
+		
+		result = Integer.MAX_VALUE;
+		Set<Integer> setA = new HashSet<>();
+		for(int i=1;i<=N/2;i++) {
+			backTracking(1,0,i,setA);
+		}
+		
+		if(result == Integer.MAX_VALUE) result = -1;
+		
+		System.out.println(result);
+	}
+	
+	
+	static void backTracking(int start, int depth, int n, Set<Integer> setA) {
+		if(depth==n) {
+			gerrymandering(setA);
+			return;
+		}
+		
+		for(int i=start;i<=N;i++) {
+			setA.add(i);
+			backTracking(i+1, depth+1, n, setA);
+			setA.remove(i);
+		}
+	}
+	
+	static void gerrymandering(Set<Integer> setA) {
+		if(!isConnected(setA)) return;
+		int populationA = p;
+		Set<Integer> setB = new HashSet<Integer>();
+		for(int i=1; i<=N;i++) {
+			if(setA.contains(i)) continue;
+			setB.add(i);
+		}
+		
+		if(!isConnected(setB)) return;
+		int populationB = p;
+		
+		result = Math.min(result, Math.abs(populationA-populationB));
+	}
+	
+	
+	static boolean isConnected(Set<Integer> set) {
+		boolean [] visited = new boolean[N+1];
+		Queue<Integer> que = new LinkedList<>();
+		int start = set.iterator().next();
+		visited[start] = true;
+		p = population[start];
+		que.offer(start);
+		int cnt = 1;
+		
+		while(!que.isEmpty()) {
+			int now = que.poll();
+			for(int i=0;i<graph.get(now).size();i++) {
+				int nxt = graph.get(now).get(i);
+				
+				if(visited[nxt] || !set.contains(nxt)) continue;
+				
+				cnt++;
+				visited[nxt] = true;
+				p+=population[nxt];
+				que.offer(nxt);
+			}
+		}
+		
+		return (cnt==set.size()) ? true : false;
+	}
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+}


### PR DESCRIPTION
### 제가 조금 밀려서..복습하듯 편하게 봐주시면 감사합니다.

## 문제 링크

- 문제 링크 : https://www.acmicpc.net/problem/17471

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="1172" height="33" alt="image" src="https://github.com/user-attachments/assets/9d46cdb9-5e55-4645-bd33-a20f7110b97e" />

<br>

## 접근 방식
> 처음엔 bfs로 연결된 그룹이 2개 이상, 2개, 1개인 경우로 나누어서 생각하다가, 1개인 그룹(모두 연결된 경우)에 대해서 어떤 식으로 구역을 나누고 풀이해야 하는지 접근을 못해서,, 통과 풀이를 참고하여 해결했습니다.
> 원 방식 대로 bfs로 먼저 연결된 그룹 카운팅을 하는 풀이가 정답 풀이를 보니 효율이 별로일 것 같아서, 조합으로 모든 경우의 수에서 카운팅하는 방식으로 풀이했습니다.

## 문제 풀이 요약
> 백트래킹으로 그룹(set사용)을 생성하여 모든 조합을 탐색
> 해당 그룹A가 연결된 상태인지 확인 , 그룹 A가 연결된 그룹이라면 나머지 지역구가 존재하는 그룹B를 생성하여 연결된 상태인지 확인
> 연결된 상태인지 확인하면서 인구수를 저장해나가서 연산

## 리뷰 요청 포인트
> 어렵읍니다. 다시 풀어보겠습니다.

## 기타 회고
> 어떻게 풀이해야할지 쪼개어 생각하기.


<br>

### 🫡 오늘도 고생하셨습니다!



