### PR TITLE
[21차시] 박정훈 - 6549번 히스토그램에서 가장 큰 직사각형

### DIFF
--- a/박정훈/21차시/BOJ_6549.java
+++ b/박정훈/21차시/BOJ_6549.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ_6549 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        
+        while(true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int N = Integer.parseInt(st.nextToken());
+            
+            // 0이면 입력 종료
+            if (N == 0) break;
+            
+            // 막대 높이 입력
+            long[] heights = new long[N + 2]; // 양쪽에 0을 추가
+            for (int i = 1; i <= N; i++) {
+                heights[i] = Long.parseLong(st.nextToken());
+            }
+            
+            // 스택으로 활용
+            Deque<Integer> stack = new ArrayDeque<>();
+            long maxArea = 0;
+            
+            for (int i = 0; i < N + 2; i++) {
+            	// 스택이 비어있지 않고 막대의 높이가 작아져서 이상으로 확장이 불가
+                while (!stack.isEmpty() && heights[stack.peek()] > heights[i]) {
+                	// 마지막 막대의 인덱스
+                    int index = stack.pop();
+                    // 오른쪽으로 확장할 너비 (index ~ i까지는 같거나 높은 막대만 있어서 현재 높이로 확장이 가능
+                    long width = i - stack.peek() - 1;
+                    maxArea = Math.max(maxArea, heights[index] * width);
+                }
+                stack.push(i);
+            }
+            
+            sb.append(maxArea).append("\n");
+        }
+        
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
# 6549번 히스토그램에서 가장 큰 직사각형

## 문제 링크

- 문제 링크 : [6549번 히스토그램에서 가장 큰 직사각형](https://www.acmicpc.net/problem/6549)

## 시간 복잡도 및 공간 복잡도
- 시간 복잡도: O(N)
<img width="694" height="72" alt="image" src="https://github.com/user-attachments/assets/1c61d37c-974e-4b35-96ca-7beac26f638f" />


<br>

## 접근 방식
막대마다 확장이 가능한 영역 내에서만 검사


## 문제 풀이 요약
- 막대 양 끝에 높이가 0인 막대를 추가 => 양 끝 막대의 경계 처리
- 막대가 오름차순이면 스택에 추가 => 현재 막대는 왼쪽으로 확장이 불가능
- 막대가 내림차순이면 스택에서 하나씩 빼서 현재 인덱스까지 확장한 넓이를 계산 => 높이가 낮아져서 오른쪽으로 확장이 불가능


## 리뷰 요청 포인트
X

## 기타 회고
할 게 많아서 조금만 고민하다가 그냥 답을 봤습니다.
다들 세그먼트로 푸시는 거 같아서 다른 좋은 풀이가 있길래 그걸로 풀어봤습니다.


<br>

### 🫡 오늘도 고생하셨습니다!



