### PR TITLE
[24차시] 변채원 - 1949번 우수 마을

### DIFF
--- a/변채원/24차시/BOJ_1949.java
+++ b/변채원/24차시/BOJ_1949.java
@@ -1,0 +1,56 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BOJ_1949 {
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+    static int[][] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+
+        graph = new ArrayList[N + 1];
+        for(int i = 0; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        visited = new boolean[N + 1];
+        dp = new int[N + 1][2]; // 0: 선택, 1: 비선택
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            int n = Integer.parseInt(st.nextToken());
+            dp[i][0] = n;
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+        
+        dfs(1);
+        System.out.println(Math.max(dp[1][0], dp[1][1]));
+    }
+
+    static void dfs(int start) {
+        visited[start] = true;
+
+        for (int i = 0; i < graph[start].size(); i++) {
+            int next = graph[start].get(i);
+
+            if(!visited[next]) {
+                dfs(next);
+                dp[start][0] += dp[next][1]; // 자신이 우수 마을 > 자식은 무조건 비우수
+                dp[start][1] += Math.max(dp[next][0], dp[next][1]); // 자신이 비우수 마을
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제 링크

- 문제 링크 : [1949](https://www.acmicpc.net/problem/1949)

## 시간 복잡도 및 공간 복잡도
<img width="1029" height="44" alt="image" src="https://github.com/user-attachments/assets/7f49e6c6-dc8f-4cbe-9ef3-26f8a7c107b7" />
<br>

## 접근 방식
- 처음에는 우선순위 큐를 사용해서 큰 cost부터 확인하여 인접한 마을은 선택하지 않는 방식으로 구현해주었습니다. 그러나 문제를 다시 보니 우수 마을로 선정된 마을 주민 수의 "최댓값"이었고 해당 방식이 아니라는 것을 알게 되었습니다.
- 이후 계속 고민하다가 문제 분류를 보게 됐고 `트리에서의 DP`라는 걸 알게 되었습니다..


## 문제 풀이 요약
- 아무데서나 시작해도 됨
- 이후 말단 노드까지 타고 들어가, 현재 노드와 자식 노드를 비교
  - 현재 본인 노드가 우수 마을이라면 무조건 자식 노드가 비우수 마을이어야 함
  - 현재 본인 노드가 비우수 마을이라면 자식 노드가 무엇이든 상관없음 


## 리뷰 요청 포인트
- dp 말고 다른 풀이 방법은 없을까요?

## 기타 회고
- 아직도 모르는 알고리즘이 있다니... 쉽지 않네요


<br>

### 🫡 오늘도 고생하셨습니다!



