### PR TITLE
[24차시] 천보성 - 1949 우수마을

### DIFF
--- a/.idea/algorithm_daejeon6_hard.iml
+++ b/.idea/algorithm_daejeon6_hard.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/algorithm_daejeon6_hard.iml" filepath="$PROJECT_DIR$/.idea/algorithm_daejeon6_hard.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/천보성/24차시/BOJ_1949.java
+++ b/천보성/24차시/BOJ_1949.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+class BOJ_1949 {
+    static int[][] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] people = new int[N+1];
+        dp = new int[N+1][2];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i=1;i<=N;i++){
+            people[i] = Integer.parseInt(st.nextToken());
+            dp[i][1] = people[i];
+        }
+
+        ArrayList<ArrayList<Integer>> tree = new ArrayList<>();
+        for (int i=0;i<N+1;i++){
+            tree.add(new ArrayList<>());
+        }
+
+        for (int i=0;i<N-1;i++){
+            st = new StringTokenizer(br.readLine());
+            int n1 = Integer.parseInt(st.nextToken());
+            int n2 = Integer.parseInt(st.nextToken());
+
+            tree.get(n1).add(n2);
+            tree.get(n2).add(n1);
+        }
+        dfs(tree, people, 1, 0);
+
+        System.out.println(Math.max(dp[1][0], dp[1][1]));
+
+    }
+    private static void dfs(ArrayList<ArrayList<Integer>> tree, int[] people, int n, int p){
+
+        for (int i:tree.get(n)){
+            if (p != i){
+                dfs(tree, people, i, n);
+                dp[n][0] += Math.max(dp[i][0], dp[i][1]);
+                dp[n][1] += dp[i][0];
+            }
+        }
+
+    }
+}


### PR DESCRIPTION

## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/1949)

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="259" height="44" alt="image" src="https://github.com/user-attachments/assets/861795fc-4741-4a18-a34e-c9faf05a01cb" />

<br>

## 접근 방식

트리 구조에서 인접 노선을 선택 못 하는 조건 보고 바로 트리 DP를 떠올렸습니다. 각 마을마다 선택하는 경우와 선택하지 않는 경우 두 가지로 나눠서 점화식을 세우면 풀릴 거라고 생각했습니다.

## 문제 풀이 요약

- DP 배열을 dp[마을번호][선택여부]로 정의. [1]은 선택, [0]은 미선택.
- DFS로 리프 노드부터 탐색하며 올라오는 방식으로 DP 테이블 채움.
- 현재 마을을 선택 안 하면(dp[n][0]), 자식은 선택/미선택 중 최댓값을 더함.
- 현재 마을을 선택하면(dp[n][1]), 자식은 무조건 미선택 경우만 더함.
- 최종적으로 루트 노드의 두 가지 경우(dp[1][0], dp[1][1]) 중 최댓값이 정답.

## 리뷰 요청 포인트


## 기타 회고



<br>

### 🫡 오늘도 고생하셨습니다!



