### PR TITLE
[25차시] 천보성 - 1517번 버블 소트

### DIFF
--- a/천보성/25차시/BOJ_1517.java
+++ b/천보성/25차시/BOJ_1517.java
@@ -1,0 +1,85 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class BOJ_1517 {
+	
+	static class Number implements Comparable<Number>{
+		int index;
+		int value;
+		
+		Number(int index, int value){
+			this.index = index;
+			this.value = value;
+		}
+
+		@Override
+		public int compareTo(Number o) {
+			if(o.value == this.value) {
+				return o.index - this.index;
+			}
+			return o.value - this.value;
+		}
+	}
+	
+	static long[] tree;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		PriorityQueue<Number> pq = new PriorityQueue<>();
+		
+		for(int i=1;i<=N;i++) {
+			pq.add(new Number(i, Integer.parseInt(st.nextToken())));
+		}
+		
+		long ans = 0;
+		tree = new long[N*4];
+		
+		while(!pq.isEmpty()) {
+			Number num = pq.poll();
+			
+			long scale = sum(1, 1, num.index-1, 1, N);
+			ans += pq.size() - (num.index + scale) + 1;
+			update(1, 1, N, num.index, -1);
+		}
+		
+		System.out.println(ans);
+		
+	}
+	
+	
+	public static long sum(int node, int targetL, int targetR, int start, int end){
+		if(end < targetL || start > targetR) {
+			return 0;
+		}
+		if(targetL <= start && targetR >= end) {
+			return tree[node];
+		}
+		
+		int mid = (start + end) / 2;
+		
+		long left = sum(node * 2, targetL, targetR, start, mid);
+		long right = sum(node * 2 + 1, targetL, targetR, mid + 1, end);
+		
+		return left + right;
+	}
+	
+	public static void update(int node, int start, int end, int index, int value) {
+		if(index < start || end < index) {
+			return;
+		}
+		tree[node] += value;
+		
+		if(start != end) {
+			int mid = (start + end) / 2;
+			update(node * 2, start, mid, index, value);
+			update(node * 2 + 1, mid + 1, end, index, value);
+		}
+	}
+}


### PR DESCRIPTION


## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/1517)

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="724" height="35" alt="image" src="https://github.com/user-attachments/assets/814038fe-c55b-41f2-8242-3c93d4ca8e91" />

<br>

## 접근 방식
버블 소트가 무엇인지부터 생각을 했습니다.
버블 소트의 특성상 1회전을 돌리면 가장 큰 수가 맨 뒤, 다음 회전은 그 다음 큰 수가 뒤.. 이런 식으로 진행됩니다.
그 숫자의 값과 인덱스를 활용하면 해결되지 않을까 생각했습니다. 

우선 순위 큐로 가장 큰 수부터 뽑고, 
그 수의 인덱스보다 앞에 있는 숫자들은 위치가 변함이 없고
 뒤에 있는 숫자들은 앞으로 당겨질테니 그것을 기록할 만한 자료 구조가 필요했습니다.

처음에는 단순 배열을 생각했으나 특정 숫자의 차례가 됐을 때 그 숫자의 인덱스보다 앞 
즉, 처음부터 index - 1 까지의 구간을 합해서 가중치를 계산했어야 했고 이것은 시간 초과로 직결될 것 같았습니다.
구간의 합, 그리고 1회전을 돌 때마다 가중치를 업데이트를 해야 하니 세그먼트 트리가 생각이 났고 적용을 했습니다.



## 문제 풀이 요약
- 우선 순위 큐로 큰 수부터 처리
- 세그먼트 트리를 사용해서 가중치 계산
-  가중치는 인덱스가 얼마나 당겨져야 하는지를 나타냄


## 리뷰 요청 포인트


## 기타 회고



<br>

### 🫡 오늘도 고생하셨습니다!



