### PR TITLE
[25차시] 안도형 - 1517번 버블 소트

### DIFF
--- a/안도형/25차시/BOJ_1517.java
+++ b/안도형/25차시/BOJ_1517.java
@@ -1,0 +1,61 @@
+package algo_hard;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class BOJ_1517 {
+	static long[] node;
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int N = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(br.readLine());
+        
+        node = new long[N + 1];
+        Integer[] arr = new Integer[N];
+        int[] originArr = new int[N];
+        HashMap<Integer, Integer> map = new HashMap<>();
+        for(int i = 0; i < N; i++) {
+        	arr[i] = Integer.parseInt(st.nextToken());
+        	originArr[i] = arr[i];
+        }
+        
+        Arrays.sort(arr, (a, b) -> a - b);
+        
+        for(int i = 0; i < N; i++) {
+        	map.put(arr[i], i + 1);
+        }
+        
+        long result = 0;
+        for(int i = N - 1; i >= 0; i--) {
+        	result += sum(map.get(originArr[i]) - 1);
+        	add(map.get(originArr[i]), 1);
+        }
+        
+        System.out.println(result);
+	}
+	
+	public static void add(int idx, int num) {
+		
+		while(idx < node.length) {
+			node[idx] += num;
+			idx += (idx & -idx);
+		}
+	}
+	
+	public static long sum(int idx) {
+		long result = 0;
+		while(idx > 0) {
+			result += node[idx];
+			idx -= (idx & -idx);
+		}
+		
+		return result;
+	}
+
+	
+}


### PR DESCRIPTION
## 문제 링크

- 문제 링크 : [바로가기](https://www.acmicpc.net/problem/1517)

## 시간 복잡도 및 공간 복잡도
<img width="552" height="32" alt="image" src="https://github.com/user-attachments/assets/01d91b03-f952-4598-8ffb-2be3507244a1" />


<br>

## 접근 방식
> 병합 정렬을 떠올렸다가 조금 더 복잡해서 펜윅 트리 + 인덱스 압축으로 풀었습니다.
> 배열을 정렬한 것과 정렬하지 않은 것 두 개를 두고 정렬된 배열을 순서를 매겨 인덱스를 압축하고 
> 정렬되지 않은 기존 배열을 기준으로 뒤에서 부터 펜윅 트리로 현재 순서보다 -1 작은 값을 더 해주고 현재 순서를 업데이트를 해주었습니다.

## 기타 회고
> 아마 병합 정렬로 풀게 된다면 좌표 압축이 필요 없어서 더 빠를 것 같습니다.


<br>

### 🫡 오늘도 고생하셨습니다!



