### PR TITLE
 [27차시] 남우성 - 2887번 행성 터널

### DIFF
--- a/남우성/27차시/2887.java
+++ b/남우성/27차시/2887.java
@@ -1,0 +1,115 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+	static class Planet{
+		int id;
+		int x;
+		int y;
+		int z;
+		
+		public Planet(int id, int x, int y, int z) {
+			this.id = id;
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+	}
+	
+	static class Dist implements Comparable<Dist>{
+		int start;
+		int end;
+		int dist;
+		
+		public Dist(int start, int end, int dist) {
+			this.start = start;
+			this.end = end;
+			this.dist = dist;
+		}
+
+		@Override
+		public int compareTo(Dist other) {
+			return this.dist - other.dist;
+		}
+	}
+	
+	static int[] root;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		int N = Integer.parseInt(br.readLine());
+		
+		Planet[] arr = new Planet[N];
+		
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			arr[i] = new Planet(i + 1, Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));
+		}
+		
+		// 가능한 모든 경우를 pq에 저장. 3 * N^2에 대해 모든 가능한 경우를 다 저장하면 시간초과이므로 정렬해서 3(N-1)개만 저장
+		PriorityQueue<Dist> pq = new PriorityQueue<>();
+		
+		// x기준 정렬 후 N-1 개의 가능한 연결 정보를 pq에 저장
+		Arrays.sort(arr, (a, b) -> {return a.x - b.x;} );
+		for(int i = 0; i < N - 1; i++) {
+			Planet left = arr[i];
+			Planet right = arr[i+1];
+			
+			pq.add(new Dist(left.id, right.id, right.x - left.x));
+		}
+		
+		// y기준
+		Arrays.sort(arr, (a, b) -> {return a.y - b.y;} );
+		for(int i = 0; i < N - 1; i++) {
+			Planet left = arr[i];
+			Planet right = arr[i+1];
+			
+			pq.add(new Dist(left.id, right.id, right.y - left.y));
+		}
+		
+		// z기준
+		Arrays.sort(arr, (a, b) -> {return a.z - b.z;} );
+		for(int i = 0; i < N - 1; i++) {
+			Planet left = arr[i];
+			Planet right = arr[i+1];
+			
+			pq.add(new Dist(left.id, right.id, right.z - left.z));
+		}
+		
+		// 연결관계 확인을 위해 유니온 파인드를 사용
+		root = new int[N+1];
+		for(int i = 1; i <= N; i++) {
+			root[i] = i;
+		}
+		
+		long result = 0;
+		while(!pq.isEmpty()) {
+			Dist now = pq.poll();
+			
+			if(union(now.start, now.end)) { // union으 실제로 수행했다면 해당 통로를 이은 걸로 판단
+				result += now.dist;
+			}
+		}
+		
+		System.out.println(result);
+	}
+	
+	static boolean union(int n1, int n2) {
+		int r1 = find(n1); int r2 = find(n2);
+		if(r1 == r2) return false;
+		
+		root[r1] = r2;
+		return true;
+	}
+	
+	static int find(int n) {
+		if(root[n] == n) return n;
+		
+		return root[n] = find(root[n]);
+	}
+}


### PR DESCRIPTION
## 문제 링크

- 문제 링크 : [2887](https://www.acmicpc.net/problem/2887)

## 시간 복잡도 및 공간 복잡도
- 문제풀이에 소요된 시간, 메모리 (사진 첨부 가능)
<img width="934" height="29" alt="image" src="https://github.com/user-attachments/assets/c02e9bf2-402b-4e23-9460-825d83a65d32" />



<br>

## 접근 방식
- 처음 문제 보고 든 생각은 전형적인 최소 스패닝 트리 문제라 판단(프림이나 크루스칼)
- 근데 문제가 N이 10만이라 전체 N에 대해 각각의 모든 경로를 다 판단하면 N^2이 되고, 이러면 시간초과
=> 이걸 어떻게 개선할 지 고민함
=> 핵심은 거리가 유클리드거리가 아니라 단순 좌표하나 기준 절대값 차이
=> 모든 N^2의 거리를 다 고려할 필요 없을 거라 생각함


## 문제 풀이 요약
- X, Y, Z 각 좌표별로 먼저 정렬을 각각 진행하고, 정렬 후에 자신과 인접한 행성에 대해서만 거리를 저장
=> 하나의 좌표 별로 N-1개의 경로만 나오고, 총 3(N-1)개의 경로만 유의미하게 선별 가능
- 모든 가능한 경로를 PQ에 넣고 크루스칼로 처리(그리디하게), 연결 여부는 유니온 파인드로 판단

> 이 문제는 크루스칼이나 프림을 쓰는데, 시간을 고려해서 필요한 통로만 판단하는 걸 떠올리는 게 중요한 문제인 것 같네요


<br>

### 🫡 오늘도 고생하셨습니다!



